### PR TITLE
Added darwin 386 syscalls file.

### DIFF
--- a/syscalls_darwin_386.go
+++ b/syscalls_darwin_386.go
@@ -1,0 +1,39 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs syscalls.go
+
+package termbox
+
+type syscall_Termios struct {
+	Iflag	uint32
+	Oflag	uint32
+	Cflag	uint32
+	Lflag	uint32
+	Cc	[20]uint8
+	Ispeed	uint32
+	Ospeed	uint32
+}
+
+const (
+	syscall_IGNBRK	= 0x1
+	syscall_BRKINT	= 0x2
+	syscall_PARMRK	= 0x8
+	syscall_ISTRIP	= 0x20
+	syscall_INLCR	= 0x40
+	syscall_IGNCR	= 0x80
+	syscall_ICRNL	= 0x100
+	syscall_IXON	= 0x200
+	syscall_OPOST	= 0x1
+	syscall_ECHO	= 0x8
+	syscall_ECHONL	= 0x10
+	syscall_ICANON	= 0x100
+	syscall_ISIG	= 0x80
+	syscall_IEXTEN	= 0x400
+	syscall_CSIZE	= 0x300
+	syscall_PARENB	= 0x1000
+	syscall_CS8	= 0x300
+	syscall_VMIN	= 0x10
+	syscall_VTIME	= 0x11
+
+	syscall_TCGETS	= 0x402c7413
+	syscall_TCSETS	= 0x802c7414
+)


### PR DESCRIPTION
I built a syscalls_darwin_386.go file to get termbox-go to build (and test) on my machine (Mac OS X 10.6 - x86-32).
