### PR TITLE
Don't assume even length of names section

### DIFF
--- a/terminfo.go
+++ b/terminfo.go
@@ -75,7 +75,7 @@ func setup_term() (err error) {
 		return
 	}
 
-	if header[2]%2 != 0 {
+	if (header[1] + header[2])%2 != 0 {
 		// old quirk to align everything on word boundaries
 		header[2] += 1
 	}


### PR DESCRIPTION
When I implemented this part, I thought that as a consequnce of the passage "...to ensure that the number section begins on an even byte" from the `term(5)` manpage, the boolean section must have an even size, but I forgot that the names section may have an odd size, too. So, if the length of both the boolean section and the names section of a terminfo entry were odd, termbox would read false string offsets, possibly resulting in an EOF error. This commit fixes this behaviour.

Fixes #10.
