### PR TITLE
Handle Alt+Esc or Esc+Esc in InputAlt correctly 

### DIFF
--- a/termbox.go
+++ b/termbox.go
@@ -249,9 +249,15 @@ func extract_event(event *Event) bool {
 			return true
 		case InputAlt:
 			// if we're in alt mode, set Alt modifier to event and redo parsing
-			event.Mod = ModAlt
 			copy(inbuf, inbuf[1:])
 			inbuf = inbuf[:len(inbuf)-1]
+			if event.Mod == ModAlt {
+				// Esc or Alt was already pressed, so return Alt + Esc
+				event.Ch = 0
+				event.Key = KeyEsc
+				return true
+			}
+			event.Mod = ModAlt
 			return extract_event(event)
 		default:
 			panic("unreachable")


### PR DESCRIPTION
If another `ESC` byte appears when termbox is in `InputAlt` and an `ESC` byte was already detected, the byte is just discarded. This leads to Alt+Esc being ignored.

This commit fixes this behaviour: If Alt+Esc is pressed in InputAlt mode, an event with `{Key: KeyEsc, Mod: ModAlt}` is generated. This also happens if Esc is pressed twice.
