### PR TITLE
Call get_win_size() after create_console_screen_buffer(). CreateConsoleScreenBuffer inherits window size.

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -35,12 +35,12 @@ func Init() error {
 		return err
 	}
 
-	w, h := get_win_size(out)
 	orig_screen = out
 	out, err = create_console_screen_buffer()
 	if err != nil {
 		return err
 	}
+	w, h := get_win_size(out)
 
 	err = set_console_screen_buffer_size(out, coord{short(w), short(h)})
 	if err != nil {


### PR DESCRIPTION
When calling executable with `system()` which use termbox-go on windows, it causes panic at get_win_size().
It should be moved after calling create_console_screen_buffer.
