### PR TITLE
fix cjk rendering bug on windows

### DIFF
--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -373,6 +373,8 @@ func prepare_diff_messages() {
 	diffbuf = diffbuf[:0]
 	beg_x = -1
 
+        attr_beg_i := 0
+
 	for y := 0; y < front_buffer.height; y++ {
 		line_offset := y * front_buffer.width
 		for x := 0; x < front_buffer.width; {
@@ -386,7 +388,7 @@ func prepare_diff_messages() {
 					// commit it
 					diffbuf = append(diffbuf, diff_msg{
 						coord{short(beg_x), short(beg_y)},
-						attrsbuf[beg_i:],
+						attrsbuf[attr_beg_i:],
 						charsbuf[beg_i:],
 					})
 					beg_x = -1
@@ -402,6 +404,7 @@ func prepare_diff_messages() {
 				// no started sequence, start one
 				beg_x, beg_y = x, y
 				beg_i = len(charsbuf)
+                                attr_beg_i = len(attrsbuf)
 			}
 			attr, char := cell_to_char_info(*back)
 			if w == 2 && x == front_buffer.width-1 {
@@ -420,7 +423,9 @@ func prepare_diff_messages() {
 				// characters, it's not true, but in
 				// most cases it is
 				attrsbuf = append(attrsbuf, attr)
-				charsbuf = append(charsbuf, char[1])
+                                if char[1] != ' ' {
+                                        charsbuf = append(charsbuf, char[1])
+                                }
 
 				// for wide runes we also trash the next cell,
 				// so that it gets updated correctly later, we
@@ -443,7 +448,7 @@ func prepare_diff_messages() {
 		// commit it
 		diffbuf = append(diffbuf, diff_msg{
 			coord{short(beg_x), short(beg_y)},
-			attrsbuf[beg_i:],
+			attrsbuf[attr_beg_i:],
 			charsbuf[beg_i:],
 		})
 	}


### PR DESCRIPTION
I just use chinese to explain the problem, almost all of the chinese words can be stored in 2 bytes(http://zh.wikipedia.org/wiki/UTF-16),for example:朱[31 67],but few words is stored as 4 bytes, and editors like vim or emacs doesn't support rendering them, so I choose to ingore them, just consider the cjk word has 2 bytes.
So cell_to_char_info's return array "char", char[1] will mostly be ' ',and the real word '朱' actually is in char[0]. And i don't need to call "charsbuf = append(charsbuf, char[1])
" at this time(that's why termbox-demo2 rendering some non-need space on windows during write cjk words).
I' show you the difference after change.
![unfixed_a](https://f.cloud.github.com/assets/4971777/2267578/06380b46-9eba-11e3-9f2a-df654fcc027f.png)
![unfixed_output](https://f.cloud.github.com/assets/4971777/2267577/0637aa98-9eba-11e3-980d-6bee5b739740.png)
above is the unfix-version
![fix_a](https://f.cloud.github.com/assets/4971777/2267584/2709a460-9eba-11e3-952e-61da7d46ec95.png)
![fix_output](https://f.cloud.github.com/assets/4971777/2267585/270a0ef0-9eba-11e3-94ca-7dd488f47f02.png)
and these are fixed-version (I also changed the gocui project which is based on termbox-go)
