### PR TITLE
Adding var IsInit to the API to know if termbox has been init or not

### DIFF
--- a/api.go
+++ b/api.go
@@ -104,6 +104,7 @@ func Init() error {
 		}
 	}()
 
+	IsInit = true
 	return nil
 }
 
@@ -136,6 +137,7 @@ func Close() {
 	cursor_y = cursor_hidden
 	foreground = ColorDefault
 	background = ColorDefault
+	IsInit = false
 }
 
 // Synchronizes the internal back buffer with the terminal.

--- a/api_common.go
+++ b/api_common.go
@@ -35,6 +35,11 @@ type Cell struct {
 	Bg Attribute
 }
 
+// To know if termbox has been initialized or not
+var (
+	IsInit bool = false
+)
+
 // Key constants, see Event.Key field.
 const (
 	KeyF1 Key = 0xFFFF - iota


### PR DESCRIPTION
Hello,

I'm creating a little library over termbox-go, and to be able to properly close termbox, I need to know if it has not been already closed somewhere else. (Because, with more than one Close(), the prompt is not given back withtout pressing ctrl+c (on linux) when the program exits)

So, I just added a variable to know the state of termbox.

Hope you'll accept it,
Regards,
Peekmo
