### PR TITLE
Implement Stringer-interface for Key and Attribute

### DIFF
--- a/api_common.go
+++ b/api_common.go
@@ -160,3 +160,72 @@ const (
 	EventMouse
 	EventError
 )
+
+const UnknownStringIdentifier string = "<unknown>"
+
+var key2string = map[Key]string{
+	KeyF1: "F1",
+	KeyF2: "F2",
+	KeyF3: "F3",
+	// ... TODO
+	KeyInsert: "insert",
+	KeyDelete: "delete",
+	KeyHome:   "home",
+	KeyEnd:    "end",
+	KeyPgup:   "pgup",
+	KeyPgdn:   "pgdn",
+	// ... TODO
+	MouseLeft:   "mouseleft",
+	MouseMiddle: "mousemiddle",
+	MouseRight:  "mouseright",
+}
+
+func (k Key) String() string {
+	s, ok := key2string[k]
+	if ok {
+		return s
+	} else {
+		return UnknownStringIdentifier
+	}
+}
+
+func StringToKey(s string) (Key, bool) {
+	for key, name := range key2string {
+		if s == name {
+			return key, true
+		}
+	}
+	return 0, false
+}
+
+var color2string = map[Attribute]string{
+	ColorDefault: "defaultcolor",
+	ColorBlack:   "black",
+	ColorRed:     "red",
+	ColorGreen:   "green",
+	ColorYellow:  "yellow",
+	ColorBlue:    "blue",
+	ColorMagenta: "magenta",
+	ColorCyan:    "cyan",
+	ColorWhite:   "white",
+}
+
+func (a Attribute) String() string {
+	a &= (ColorDefault | ColorBlack | ColorRed | ColorGreen | ColorYellow |
+		ColorBlue | ColorMagenta | ColorCyan | ColorWhite)
+	s, ok := color2string[a]
+	if ok {
+		return s
+	} else {
+		return UnknownStringIdentifier
+	}
+}
+
+func StringToColor(s string) (Attribute, bool) {
+	for color, name := range color2string {
+		if s == name {
+			return color, true
+		}
+	}
+	return 0, false
+}

--- a/api_common_test.go
+++ b/api_common_test.go
@@ -1,0 +1,37 @@
+package termbox
+
+import "testing"
+
+func TestKeyStringer(t *testing.T) {
+	if KeyF1.String() != "F1" {
+		t.Error("Key F1 should be named 'F1'")
+	}
+
+	k, ok := StringToKey("F1")
+	if !ok || k != KeyF1 {
+		t.Error("'F1' should result in Key F1")
+	}
+
+	if Key(0x1234).String() != UnknownStringIdentifier {
+		t.Error("Unknown Key should be named as such")
+	}
+}
+
+func TestColorStringer(t *testing.T) {
+	if ColorBlack.String() != "black" {
+		t.Error("Black should be 'black'")
+	}
+
+	c, ok := StringToColor("black")
+	if !ok || c != ColorBlack {
+		t.Error("'black' should be Black")
+	}
+
+	if (ColorWhite | AttrBold).String() != "white" {
+		t.Error("Bold White should be 'white'")
+	}
+
+	if Attribute(0xFFFF).String() != UnknownStringIdentifier {
+		t.Error("Unknown Color should be named as such")
+	}
+}


### PR DESCRIPTION
It would be nice if termbox understood human-readable representations of keys and colors. This would allow to display keystrokes on GUIs, load & safe hotkeys from setting files etc without digging to deeply into termbox's code. The main motivation is to prevent lestrrat/peco and all the others from re-implementing this over and over again.

I may add the other keys upon request...
