### PR TITLE
Fix SetInputMode on windows. it can't set InputAlt without setting enable_window_input

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -181,7 +181,7 @@ func SetInputMode(mode InputMode) InputMode {
 		if err != nil {
 			panic(err)
 		}
-	} else {
+	} else if mode&InputAlt == 0 {
 		err := set_console_mode(in, enable_window_input)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
I want to set InputAlt without enable_window_input.
