### PR TITLE
Move output_mode into termbox_common to fix cross-compilation errors

### DIFF
--- a/termbox.go
+++ b/termbox.go
@@ -53,7 +53,6 @@ var (
 	termw        int
 	termh        int
 	input_mode   = InputEsc
-	output_mode  = OutputNormal
 	out          *os.File
 	in           int
 	lastfg       = attr_invalid

--- a/termbox_common.go
+++ b/termbox_common.go
@@ -1,6 +1,9 @@
 package termbox
 
 // private API, common OS agnostic part
+var (
+	output_mode  = OutputNormal
+)
 
 type cellbuf struct {
 	width  int


### PR DESCRIPTION
I'm currently unable to cross-compile an application for windows due to the following error:

```
bash-4.1$ GOOS=windows GOARCH=amd64 go build ...
# github.com/nsf/termbox-go
nsf/termbox-go/api_windows.go:197: undefined: output_mode
nsf/termbox-go/api_windows.go:198: undefined: output_mode
```

This PR fixes the error.
