### PR TITLE
Handle ColourDefault in extended output modes.

### DIFF
--- a/_demos/output.go
+++ b/_demos/output.go
@@ -28,7 +28,11 @@ func print_combinations_table(sx, sy int, attrs []termbox.Attribute) {
 	draw_line := func() {
 		x := sx
 		for _, a := range all_attrs {
-			for c := termbox.ColorDefault; c <= termbox.ColorWhite; c++ {
+			c := termbox.ColorDefault
+			termbox.SetCell(x, y, rune(chars[current_char]), a | c, bg)
+			current_char = next_char(current_char)
+			x++
+			for c = termbox.ColorBlack; c <= termbox.ColorWhite; c++ {
 				fg := a | c
 				termbox.SetCell(x, y, rune(chars[current_char]), fg, bg)
 				current_char = next_char(current_char)
@@ -38,7 +42,10 @@ func print_combinations_table(sx, sy int, attrs []termbox.Attribute) {
 	}
 
 	for _, a := range attrs {
-		for c := termbox.ColorDefault; c <= termbox.ColorWhite; c++ {
+		bg = a | termbox.ColorDefault
+		draw_line()
+		y++
+		for c := termbox.ColorBlack; c <= termbox.ColorWhite; c++ {
 			bg = a | c
 			draw_line()
 			y++
@@ -89,6 +96,12 @@ func draw_all() {
 					termbox.Attribute(x) | termbox.AttrUnderline,
 					termbox.Attribute(y))
 			}
+			termbox.SetCell(76, y, 'd',
+				termbox.Attribute(y),
+				termbox.ColorDefault)
+			termbox.SetCell(77, y, 'd',
+				termbox.ColorDefault,
+				termbox.Attribute(23 - y))
 		}
 
 	case termbox.Output216:
@@ -113,6 +126,12 @@ func draw_all() {
 					termbox.SetCell(x + 37, y + 12, 'u', uc2, bg)
 					termbox.SetCell(x + 37, y + 18, 'B', bc2 | uc2, bg)
 				}
+				c1 := termbox.Attribute(g*6 + r*36)
+				c2 := termbox.Attribute(5 + g*6 + r*36)
+				termbox.SetCell(74+g, r, 'd', c1, termbox.ColorDefault)
+				termbox.SetCell(74+g, r+6, 'd', c2, termbox.ColorDefault)
+				termbox.SetCell(74+g, r+12, 'd', termbox.ColorDefault, c1)
+				termbox.SetCell(74+g, r+18, 'd', termbox.ColorDefault, c2)
 			}
 		}
 
@@ -120,7 +139,7 @@ func draw_all() {
 		for y := 0; y < 4; y++ {
 			for x := 0; x < 8; x++ {
 				for z := 0; z < 8; z++ {
-					bg := termbox.Attribute(y * 64 + x * 8 + z)
+					bg := termbox.Attribute(y*64 + x*8 + z)
 					c1 := termbox.Attribute(255 - y*64 - x*8 - z)
 					c2 := termbox.Attribute(y*64 + z*8 + x)
 					c3 := termbox.Attribute(255 - y*64 - z*8 - x)
@@ -134,6 +153,23 @@ func draw_all() {
 					termbox.SetCell(z + 8*x, y+15, 'u', under, bg)
 					termbox.SetCell(z + 8*x, y+20, 'B', both, bg)
 				}
+			}
+		}
+		for x := 0; x < 12; x++ {
+			for y := 0; y < 2; y++ {
+				c1 := termbox.Attribute(232 + y*12 + x)
+				termbox.SetCell(66+x, y, 'd', c1, termbox.ColorDefault)
+				termbox.SetCell(66+x, 2+y, 'd', termbox.ColorDefault, c1)
+			}
+		}
+		for x := 0; x < 6; x++ {
+			for y := 0; y < 6; y++ {
+				c1 := termbox.Attribute(16 + x*6 + y*36)
+				c2 := termbox.Attribute(16 + 5 + x*6 + y*36)
+				termbox.SetCell(66+x, 6+y, 'd', c1, termbox.ColorDefault)
+				termbox.SetCell(66+x, 12+y, 'd', c2, termbox.ColorDefault)
+				termbox.SetCell(72+x, 6+y, 'd', termbox.ColorDefault, c1)
+				termbox.SetCell(72+x, 12+y, 'd', termbox.ColorDefault, c2)
 			}
 		}
 

--- a/api.go
+++ b/api.go
@@ -306,7 +306,7 @@ func SetInputMode(mode InputMode) InputMode {
 }
 
 // Sets the termbox output mode. Termbox has four output options:
-// 1. OutputNormal => [1..8]
+// 1. OutputNormal => [0..7]
 //    This mode provides 8 different colors:
 //        black, red, green, yellow, blue, magenta, cyan, white
 //    Shortcut: ColorBlack, ColorRed, ...
@@ -315,7 +315,7 @@ func SetInputMode(mode InputMode) InputMode {
 //    Example usage:
 //        SetCell(x, y, '@', ColorBlack | AttrBold, ColorRed);
 //
-// 2. Output256 => [0..256]
+// 2. Output256 => [0..255]
 //    In this mode you can leverage the 256 terminal mode:
 //    0x00 - 0x07: the 8 colors as in OutputNormal
 //    0x08 - 0x0f: Color* | AttrBold
@@ -326,7 +326,7 @@ func SetInputMode(mode InputMode) InputMode {
 //        SetCell(x, y, '@', 184, 240);
 //        SetCell(x, y, '@', 0xb8, 0xf0);
 //
-// 3. Output216 => [0..216]
+// 3. Output216 => [0..215]
 //    This mode supports the 3rd range of the 256 mode only.
 //    But you dont need to provide an offset.
 //

--- a/api_common.go
+++ b/api_common.go
@@ -128,8 +128,7 @@ const (
 // Cell colors, you can combine a color with multiple attributes using bitwise
 // OR ('|').
 const (
-	ColorDefault Attribute = iota
-	ColorBlack
+	ColorBlack Attribute = iota
 	ColorRed
 	ColorGreen
 	ColorYellow
@@ -148,7 +147,8 @@ const (
 // terminals applying AttrBold to background may result in blinking text. Use
 // them with caution and test your code on various terminals.
 const (
-	AttrBold Attribute = 1 << (iota + 8)
+	ColorDefault Attribute = 1 << (iota + 8)
+	AttrBold
 	AttrUnderline
 	AttrReverse
 )


### PR DESCRIPTION
This also makes ColourBlack etc. correct in 256-colour mode.

I set ColourDefault to 0x100 in stead of 0,
and AttrBold, AttrUnderline etc have been shifted,
but this should be an internal change only.

I'm not sure if this is the best way to handle it, but with 256 colour mode there's no space in 0x00-0xff for the default colour specifier, so i just used a higher bit for it.
