### PR TITLE
Support ColorDefault in extended color modes.

### DIFF
--- a/_demos/output.go
+++ b/_demos/output.go
@@ -80,15 +80,21 @@ func draw_all() {
 		for y := 0; y < 24; y++ {
 			for x:= 0; x < 24; x++ {
 				termbox.SetCell(x, y, 'n',
-					termbox.Attribute(x),
-					termbox.Attribute(y))
+					termbox.Attribute(x+1),
+					termbox.Attribute(y+1))
 				termbox.SetCell(x+25, y, 'b',
-					termbox.Attribute(x) | termbox.AttrBold,
-					termbox.Attribute(23 - y))
+					termbox.Attribute(x+1) | termbox.AttrBold,
+					termbox.Attribute(24 - y))
 				termbox.SetCell(x+50, y, 'u',
-					termbox.Attribute(x) | termbox.AttrUnderline,
-					termbox.Attribute(y))
+					termbox.Attribute(x+1) | termbox.AttrUnderline,
+					termbox.Attribute(y+1))
 			}
+			termbox.SetCell(76, y, 'd',
+				termbox.Attribute(y+1),
+				termbox.ColorDefault)
+			termbox.SetCell(77, y, 'd',
+				termbox.ColorDefault,
+				termbox.Attribute(24 - y))
 		}
 
 	case termbox.Output216:
@@ -97,9 +103,9 @@ func draw_all() {
 				for b := 0; b < 6; b++ {
 					y := r
 					x := g + 6 * b
-					c1 := termbox.Attribute(r*36 + g*6 + b)
-					bg := termbox.Attribute(g*36 + b*6 + r)
-					c2 := termbox.Attribute(b*36 + r*6 + g)
+					c1 := termbox.Attribute(1 + r*36 + g*6 + b)
+					bg := termbox.Attribute(1 + g*36 + b*6 + r)
+					c2 := termbox.Attribute(1 + b*36 + r*6 + g)
 					bc1 := c1 | termbox.AttrBold
 					uc1 := c1 | termbox.AttrUnderline
 					bc2 := c2 | termbox.AttrBold
@@ -113,6 +119,12 @@ func draw_all() {
 					termbox.SetCell(x + 37, y + 12, 'u', uc2, bg)
 					termbox.SetCell(x + 37, y + 18, 'B', bc2 | uc2, bg)
 				}
+				c1 := termbox.Attribute(1 + g*6 + r*36)
+				c2 := termbox.Attribute(6 + g*6 + r*36)
+				termbox.SetCell(74+g, r, 'd', c1, termbox.ColorDefault)
+				termbox.SetCell(74+g, r+6, 'd', c2, termbox.ColorDefault)
+				termbox.SetCell(74+g, r+12, 'd', termbox.ColorDefault, c1)
+				termbox.SetCell(74+g, r+18, 'd', termbox.ColorDefault, c2)
 			}
 		}
 
@@ -120,11 +132,11 @@ func draw_all() {
 		for y := 0; y < 4; y++ {
 			for x := 0; x < 8; x++ {
 				for z := 0; z < 8; z++ {
-					bg := termbox.Attribute(y * 64 + x * 8 + z)
-					c1 := termbox.Attribute(255 - y*64 - x*8 - z)
-					c2 := termbox.Attribute(y*64 + z*8 + x)
-					c3 := termbox.Attribute(255 - y*64 - z*8 - x)
-					c4 := termbox.Attribute(y*64 + x*4 + z*4)
+					bg := termbox.Attribute(1 + y*64 + x*8 + z)
+					c1 := termbox.Attribute(256 - y*64 - x*8 - z)
+					c2 := termbox.Attribute(1 + y*64 + z*8 + x)
+					c3 := termbox.Attribute(256 - y*64 - z*8 - x)
+					c4 := termbox.Attribute(1 + y*64 + x*4 + z*4)
 					bold := c2 | termbox.AttrBold
 					under := c3 | termbox.AttrUnderline
 					both := c1 | termbox.AttrBold | termbox.AttrUnderline
@@ -134,6 +146,23 @@ func draw_all() {
 					termbox.SetCell(z + 8*x, y+15, 'u', under, bg)
 					termbox.SetCell(z + 8*x, y+20, 'B', both, bg)
 				}
+			}
+		}
+		for x := 0; x < 12; x++ {
+			for y := 0; y < 2; y++ {
+				c1 := termbox.Attribute(233 + y*12 + x)
+				termbox.SetCell(66+x, y, 'd', c1, termbox.ColorDefault)
+				termbox.SetCell(66+x, 2+y, 'd', termbox.ColorDefault, c1)
+			}
+		}
+		for x := 0; x < 6; x++ {
+			for y := 0; y < 6; y++ {
+				c1 := termbox.Attribute(17 + x*6 + y*36)
+				c2 := termbox.Attribute(17 + 5 + x*6 + y*36)
+				termbox.SetCell(66+x, 6+y, 'd', c1, termbox.ColorDefault)
+				termbox.SetCell(66+x, 12+y, 'd', c2, termbox.ColorDefault)
+				termbox.SetCell(72+x, 6+y, 'd', termbox.ColorDefault, c1)
+				termbox.SetCell(72+x, 12+y, 'd', termbox.ColorDefault, c2)
 			}
 		}
 

--- a/api.go
+++ b/api.go
@@ -315,7 +315,7 @@ func SetInputMode(mode InputMode) InputMode {
 //    Example usage:
 //        SetCell(x, y, '@', ColorBlack | AttrBold, ColorRed);
 //
-// 2. Output256 => [0..256]
+// 2. Output256 => [1..256]
 //    In this mode you can leverage the 256 terminal mode:
 //    0x00 - 0x07: the 8 colors as in OutputNormal
 //    0x08 - 0x0f: Color* | AttrBold
@@ -326,13 +326,15 @@ func SetInputMode(mode InputMode) InputMode {
 //        SetCell(x, y, '@', 184, 240);
 //        SetCell(x, y, '@', 0xb8, 0xf0);
 //
-// 3. Output216 => [0..216]
+// 3. Output216 => [1..216]
 //    This mode supports the 3rd range of the 256 mode only.
 //    But you dont need to provide an offset.
 //
-// 4. OutputGrayscale => [0..23]
+// 4. OutputGrayscale => [1..24]
 //    This mode supports the 4th range of the 256 mode only.
 //    But you dont need to provide an offset.
+//
+// In all modes, 0 represents the default color.
 //
 // `go run _demos/output.go` to see its impact on your terminal.
 //

--- a/api_common.go
+++ b/api_common.go
@@ -148,7 +148,7 @@ const (
 // terminals applying AttrBold to background may result in blinking text. Use
 // them with caution and test your code on various terminals.
 const (
-	AttrBold Attribute = 1 << (iota + 8)
+	AttrBold Attribute = 1 << (iota + 9)
 	AttrUnderline
 	AttrReverse
 )

--- a/termbox.go
+++ b/termbox.go
@@ -82,25 +82,39 @@ func write_cursor(x, y int) {
 }
 
 func write_sgr_fg(a Attribute) {
-	outbuf.WriteString("\033[3")
-	outbuf.Write(strconv.AppendUint(intbuf, uint64(a-1), 10))
-	outbuf.WriteString("m")
+	switch output_mode {
+	case Output256, Output216, OutputGrayscale:
+		outbuf.WriteString("\033[38;5;")
+		outbuf.Write(strconv.AppendUint(intbuf, uint64(a-1), 10))
+		outbuf.WriteString("m")
+	default:
+		outbuf.WriteString("\033[3")
+		outbuf.Write(strconv.AppendUint(intbuf, uint64(a-1), 10))
+		outbuf.WriteString("m")
+	}
 }
 
 func write_sgr_bg(a Attribute) {
-	outbuf.WriteString("\033[4")
-	outbuf.Write(strconv.AppendUint(intbuf, uint64(a-1), 10))
-	outbuf.WriteString("m")
+	switch output_mode {
+	case Output256, Output216, OutputGrayscale:
+		outbuf.WriteString("\033[48;5;")
+		outbuf.Write(strconv.AppendUint(intbuf, uint64(a-1), 10))
+		outbuf.WriteString("m")
+	default:
+		outbuf.WriteString("\033[4")
+		outbuf.Write(strconv.AppendUint(intbuf, uint64(a-1), 10))
+		outbuf.WriteString("m")
+	}
 }
 
 func write_sgr(fg, bg Attribute) {
 	switch output_mode {
 	case Output256, Output216, OutputGrayscale:
 		outbuf.WriteString("\033[38;5;")
-		outbuf.Write(strconv.AppendUint(intbuf, uint64(fg), 10))
+		outbuf.Write(strconv.AppendUint(intbuf, uint64(fg-1), 10))
 		outbuf.WriteString("m")
 		outbuf.WriteString("\033[48;5;")
-		outbuf.Write(strconv.AppendUint(intbuf, uint64(bg), 10))
+		outbuf.Write(strconv.AppendUint(intbuf, uint64(bg-1), 10))
 		outbuf.WriteString("m")
 	default:
 		outbuf.WriteString("\033[3")
@@ -136,33 +150,35 @@ func send_attr(fg, bg Attribute) {
 
 	switch output_mode {
 	case Output256:
+		fgcol = fg & 0x1FF
+		bgcol = bg & 0x1FF
+	case Output216:
 		fgcol = fg & 0xFF
 		bgcol = bg & 0xFF
-		write_sgr(fgcol, bgcol)
-	case Output216:
-		fgcol = fg & 0xFF; if fgcol > 215 { fgcol = 7 }
-		bgcol = bg & 0xFF; if bgcol > 215 { bgcol = 0 }
-		fgcol += 0x10;
-		bgcol += 0x10;
-		write_sgr(fgcol, bgcol)
+		if fgcol > 216 { fgcol = ColorDefault }
+		if bgcol > 216 { bgcol = ColorDefault }
+		if fgcol != ColorDefault { fgcol += 0x10 }
+		if bgcol != ColorDefault { bgcol += 0x10 }
 	case OutputGrayscale:
-		fgcol = fg & 0xFF; if fgcol > 23 { fgcol = 23 }
-		bgcol = bg & 0xFF; if bgcol > 23 { bgcol = 0 }
-		fgcol += 0xe8;
-		bgcol += 0xe8;
-		write_sgr(fgcol, bgcol)
+		fgcol = fg & 0x1F
+		bgcol = bg & 0x1F
+		if fgcol > 24 { fgcol = ColorDefault }
+		if bgcol > 24 { bgcol = ColorDefault }
+		if fgcol != ColorDefault { fgcol += 0xe8 }
+		if bgcol != ColorDefault { bgcol += 0xe8 }
 	default:
 		fgcol = fg & 0x0F
 		bgcol = bg & 0x0F
-		if fgcol != ColorDefault {
-			if bgcol != ColorDefault {
-				write_sgr(fgcol, bgcol)
-			} else {
-				write_sgr_fg(fgcol)
-			}
-		} else if bgcol != ColorDefault {
-			write_sgr_bg(bgcol)
+	}
+
+	if fgcol != ColorDefault {
+		if bgcol != ColorDefault {
+			write_sgr(fgcol, bgcol)
+		} else {
+			write_sgr_fg(fgcol)
 		}
+	} else if bgcol != ColorDefault {
+		write_sgr_bg(bgcol)
 	}
 
 	if fg&AttrBold != 0 {


### PR DESCRIPTION
How about like this? Leaves ColorDefault as 0 in all cases, and handling is a little more consistent.

I also changed out-of-bounds values in 216 and grayscale modes to assign ColorDefault in stead of specific values.

I think i've made _demos/output.go a little messy. Should lines be kept to 80 characters long?
