### PR TITLE
Add EventShutdown event

### DIFF
--- a/_demos/interrupt.go
+++ b/_demos/interrupt.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/andrew-d/termbox-go"
+)
+
+func tbPrint(x, y int, fg, bg termbox.Attribute, msg string) {
+	for _, c := range msg {
+		termbox.SetCell(x, y, c, fg, bg)
+		x++
+	}
+}
+
+func draw(i int) {
+	termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
+	defer termbox.Flush()
+
+	w, h := termbox.Size()
+	s := fmt.Sprintf("count = %d", i)
+
+	tbPrint((w/2)-(len(s)/2), h/2, termbox.ColorRed, termbox.ColorDefault, s)
+}
+
+func main() {
+	err := termbox.Init()
+	if err != nil {
+		panic(err)
+	}
+	termbox.SetInputMode(termbox.InputEsc)
+
+	go func() {
+		time.Sleep(5 * time.Second)
+		termbox.Interrupt()
+
+		// This should never run - the Interrupt(), above, should cause the event
+		// loop below to exit, which then exits the process.  If something goes
+		// wrong, this panic will trigger and show what happened.
+		time.Sleep(1 * time.Second)
+		panic("this should never run")
+	}()
+
+	var count int
+
+	draw(count)
+mainloop:
+	for {
+		switch ev := termbox.PollEvent(); ev.Type {
+		case termbox.EventKey:
+			if ev.Ch == '+' {
+				count++
+			} else if ev.Ch == '-' {
+				count--
+			}
+
+		case termbox.EventError:
+			panic(ev.Err)
+
+		case termbox.EventInterrupt:
+			break mainloop
+		}
+
+		draw(count)
+	}
+	termbox.Close()
+
+	fmt.Println("Finished")
+}

--- a/api.go
+++ b/api.go
@@ -109,6 +109,13 @@ func Init() error {
 	return nil
 }
 
+// Interrupt an in-progress call to PollEvent by causing it to return
+// EventInterrupt.  Note that this function will block until the PollEvent
+// function has successfully been interrupted.
+func Interrupt() {
+	interrupt_comm <- struct{}{}
+}
+
 // Finalizes termbox library, should be called after successful initialization
 // when termbox's functionality isn't required anymore.
 func Close() {
@@ -253,6 +260,10 @@ func PollEvent() Event {
 			if extract_event(&event) {
 				return event
 			}
+		case <-interrupt_comm:
+			event.Type = EventInterrupt
+			return event
+
 		case <-sigwinch:
 			event.Type = EventResize
 			event.Width, event.Height = get_term_size(out.Fd())

--- a/api_common.go
+++ b/api_common.go
@@ -176,4 +176,5 @@ const (
 	EventResize
 	EventMouse
 	EventError
+	EventInterrupt
 )

--- a/termbox.go
+++ b/termbox.go
@@ -47,30 +47,31 @@ var (
 	funcs []string
 
 	// termbox inner state
-	orig_tios    syscall_Termios
-	back_buffer  cellbuf
-	front_buffer cellbuf
-	termw        int
-	termh        int
-	input_mode   = InputEsc
-	output_mode  = OutputNormal
-	out          *os.File
-	in           int
-	lastfg       = attr_invalid
-	lastbg       = attr_invalid
-	lastx        = coord_invalid
-	lasty        = coord_invalid
-	cursor_x     = cursor_hidden
-	cursor_y     = cursor_hidden
-	foreground   = ColorDefault
-	background   = ColorDefault
-	inbuf        = make([]byte, 0, 64)
-	outbuf       bytes.Buffer
-	sigwinch     = make(chan os.Signal, 1)
-	sigio        = make(chan os.Signal, 1)
-	quit         = make(chan int)
-	input_comm   = make(chan input_event)
-	intbuf       = make([]byte, 0, 16)
+	orig_tios      syscall_Termios
+	back_buffer    cellbuf
+	front_buffer   cellbuf
+	termw          int
+	termh          int
+	input_mode     = InputEsc
+	output_mode    = OutputNormal
+	out            *os.File
+	in             int
+	lastfg         = attr_invalid
+	lastbg         = attr_invalid
+	lastx          = coord_invalid
+	lasty          = coord_invalid
+	cursor_x       = cursor_hidden
+	cursor_y       = cursor_hidden
+	foreground     = ColorDefault
+	background     = ColorDefault
+	inbuf          = make([]byte, 0, 64)
+	outbuf         bytes.Buffer
+	sigwinch       = make(chan os.Signal, 1)
+	sigio          = make(chan os.Signal, 1)
+	quit           = make(chan int)
+	input_comm     = make(chan input_event)
+	interrupt_comm = make(chan struct{})
+	intbuf         = make([]byte, 0, 16)
 )
 
 func write_cursor(x, y int) {

--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -347,6 +347,7 @@ var (
 	beg_y            = -1
 	beg_i            = -1
 	input_comm       = make(chan Event)
+	interrupt_comm   = make(chan struct{})
 	cancel_comm      = make(chan bool, 1)
 	cancel_done_comm = make(chan bool)
 	alt_mode_esc     = false


### PR DESCRIPTION
This event is sent whenever termbox-go is exiting.  This allows a proper
shutdown of an event loop to occur, since it will loop forever otherwise
(even after calling `termbox.Close()`).