### PR TITLE
POC input rawmode

### DIFF
--- a/api_common.go
+++ b/api_common.go
@@ -25,6 +25,7 @@ type Event struct {
 	Err    error     // error in case if input failed
 	MouseX int       // x coord of mouse
 	MouseY int       // y coord of mouse
+	Raw    []byte    // raw data
 }
 
 // A cell, single conceptual entity on the screen. The screen is basically a 2d
@@ -158,6 +159,7 @@ const (
 	InputEsc InputMode = 1 << iota
 	InputAlt
 	InputMouse
+	InputRaw
 	InputCurrent InputMode = 0
 )
 

--- a/termbox.go
+++ b/termbox.go
@@ -321,6 +321,13 @@ func extract_event(event *Event) bool {
 		return false
 	}
 
+	// in raw mode don't parse raw inbuf
+	if input_mode&InputRaw != 0 {
+		event.Raw = inbuf
+		inbuf = []byte{}
+		return true
+	}
+
 	if inbuf[0] == '\033' {
 		// possible escape sequence
 		n, ok := parse_escape_sequence(event, inbuf)


### PR DESCRIPTION
This is a proof of concept to hand of raw terminal input to the calling application.  We all agree that terminal input is absolutely awful but this way the application can do it's own parsing and be responsible for the entire keymap.

What do you think?