### PR TITLE
Fill both event.Ch and event.Key for space (0x20)

### DIFF
--- a/termbox.go
+++ b/termbox.go
@@ -377,7 +377,7 @@ func extract_event(inbuf []byte, event *Event) bool {
 	// so, it's a FUNCTIONAL KEY or a UNICODE character
 
 	// first of all check if it's a functional key
-	if Key(inbuf[0]) <= KeySpace || Key(inbuf[0]) == KeyBackspace2 {
+	if Key(inbuf[0]) < KeySpace || Key(inbuf[0]) == KeyBackspace2 {
 		// fill event, pop buffer, return success
 		event.Ch = 0
 		event.Key = Key(inbuf[0])
@@ -388,7 +388,11 @@ func extract_event(inbuf []byte, event *Event) bool {
 	// the only possible option is utf8 rune
 	if r, n := utf8.DecodeRune(inbuf); r != utf8.RuneError {
 		event.Ch = r
-		event.Key = 0
+		if r == rune(KeySpace) {
+			event.Key = KeySpace
+		} else {
+			event.Key = 0
+		}
 		event.N = n
 		return true
 	}


### PR DESCRIPTION
Currently pressing spacebar does not fill the "Ch" field on non-Windows platforms. This creates some odd bugs in client code where ASCII Space is treated differently from other printable characters. This patch ensures the event contains non-zero values for both Ch and Key.