### PR TITLE
Fix typo, add Hecate to examples, alphabetize

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ For examples of what can be done take a look at demos in the _demos directory. Y
 
 There are also some interesting projects using termbox-go:
  - [godit](https://github.com/nsf/godit) is an emacsish lightweight text editor written using termbox.
- - [gomatrix](https://github.com/GeertJohan/gomatrix) connects to The Matrix and displays it's data streams in your terminal.
+ - [gomatrix](https://github.com/GeertJohan/gomatrix) connects to The Matrix and displays its data streams in your terminal.
+ - [gotetris](https://github.com/jjinux/gotetris) is an implementation of Tetris.
+ - [hecate](https://github.com/evanmiller/hecate) is a hex editor designed by Satan.
  - [httopd](https://github.com/verdverm/httopd) is top for httpd logs.
  - [termui](https://github.com/gizak/termui) is a terminal dashboard.
- - [gotetris](https://github.com/jjinux/gotetris) is an implementation of Tetris.
 
 ### API reference
 [godoc.org/github.com/nsf/termbox-go](http://godoc.org/github.com/nsf/termbox-go)


### PR DESCRIPTION
[Hecate](https://github.com/evanmiller/hecate) is a hex editor/viewer that makes heavy use of termbox-go. Thanks for a great library!