### PR TITLE
Add example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ There are also some interesting projects using termbox-go:
  - [httopd](https://github.com/verdverm/httopd) is top for httpd logs.
  - [mop](https://github.com/michaeldv/mop) is stock market tracker for hackers.
  - [termui](https://github.com/gizak/termui) is a terminal dashboard.
+ - [termloop](https://github.com/JoelOtter/termloop) is a terminal game engine.
 
 ### API reference
 [godoc.org/github.com/nsf/termbox-go](http://godoc.org/github.com/nsf/termbox-go)


### PR DESCRIPTION
Adds [termloop](https://github.com/JoelOtter/termloop) as an example project.