### PR TITLE
expand grayscale

### DIFF
--- a/api.go
+++ b/api.go
@@ -397,6 +397,7 @@ func SetInputMode(mode InputMode) InputMode {
 }
 
 // Sets the termbox output mode. Termbox has four output options:
+//
 // 1. OutputNormal => [1..8]
 //    This mode provides 8 different colors:
 //        black, red, green, yellow, blue, magenta, cyan, white
@@ -408,10 +409,10 @@ func SetInputMode(mode InputMode) InputMode {
 //
 // 2. Output256 => [1..256]
 //    In this mode you can leverage the 256 terminal mode:
-//    0x00 - 0x07: the 8 colors as in OutputNormal
-//    0x08 - 0x0f: Color* | AttrBold
-//    0x10 - 0xe7: 216 different colors
-//    0xe8 - 0xff: 24 different shades of grey
+//    0x01 - 0x08: the 8 colors as in OutputNormal
+//    0x09 - 0x10: Color* | AttrBold
+//    0x11 - 0xe8: 216 different colors
+//    0xe9 - 0x1ff: 24 different shades of grey
 //
 //    Example usage:
 //        SetCell(x, y, '@', 184, 240);
@@ -421,11 +422,12 @@ func SetInputMode(mode InputMode) InputMode {
 //    This mode supports the 3rd range of the 256 mode only.
 //    But you dont need to provide an offset.
 //
-// 4. OutputGrayscale => [1..24]
-//    This mode supports the 4th range of the 256 mode only.
+// 4. OutputGrayscale => [1..26]
+//    This mode supports the 4th range of the 256 mode
+//    and black and white colors from 3th range of the 256 mode
 //    But you dont need to provide an offset.
 //
-// In all modes, 0 represents the default color.
+// In all modes, 0x00 represents the default color.
 //
 // `go run _demos/output.go` to see its impact on your terminal.
 //

--- a/termbox.go
+++ b/termbox.go
@@ -72,6 +72,12 @@ var (
 	input_comm     = make(chan input_event)
 	interrupt_comm = make(chan struct{})
 	intbuf         = make([]byte, 0, 16)
+
+	// grayscale indexes
+	grayscale = []Attribute{
+		0, 17, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244,
+		245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 232,
+	}
 )
 
 func write_cursor(x, y int) {
@@ -171,17 +177,17 @@ func send_attr(fg, bg Attribute) {
 	case OutputGrayscale:
 		fgcol = fg & 0x1F
 		bgcol = bg & 0x1F
-		if fgcol > 24 {
+		if fgcol > 26 {
 			fgcol = ColorDefault
 		}
-		if bgcol > 24 {
+		if bgcol > 26 {
 			bgcol = ColorDefault
 		}
 		if fgcol != ColorDefault {
-			fgcol += 0xe8
+			fgcol = grayscale[fgcol]
 		}
 		if bgcol != ColorDefault {
-			bgcol += 0xe8
+			bgcol = grayscale[bgcol]
 		}
 	default:
 		fgcol = fg & 0x0F


### PR DESCRIPTION
В режиме OutputGrayscale невозможно вывести в консоль чистый белый и чистый черный цвет, поскольку этот диапазон палитры xterm начинается от очень-темно-серого и заканчивается очень-светло-серым. Если добавить к этому градиенту цвет 17 (черный) и 232 (белый), тогда получится полноценный градиент от черного до белого.

Это, конечно, легко реализовывается собственными силами, но раз уж в библиотеке вводится искусственный режим вывода, реализующий монохромные цвета палитры xterm, тогда он должен включать и черный и белый цвет.

Если рассматривать тембокс в отрыве от консоли, тогда вообще в этом режиме нет ни какого смысла, поскольку тогда пользователь самостоятельно задает цветовую палитру и каждому индексу волен назначать необходимый цвет.

На тех, кто использовал этот режим раньше это изменение отразится в том, что цвета этого диапазона станут на тон темнее.