### PR TITLE
Fix hang with termbox.Close() on Windows

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -80,6 +80,10 @@ func Close() {
 	// stop event producer
 	cancel_comm <- true
 	set_event(interrupt)
+	select {
+		case <-input_comm:
+		default:
+	}
 	<-cancel_done_comm
 
 	set_console_cursor_info(out, &orig_cursor_info)


### PR DESCRIPTION
`termbox.Close()` hanged up when `input_comm` channel is not polled.

Example Code:
```go
package main

import "github.com/nsf/termbox-go"
import "time"

func main() {
	termbox.Init()
	time.Sleep(1000 * time.Millisecond)
	termbox.Close()
}
```

Result:
```console
>go run test.go

fatal error: all goroutines are asleep - deadlock!

goroutine 1 [chan receive]:
github.com/nsf/termbox-go.Close()
        src/github.com/nsf/termbox-go/api_windows.go:83 +0x95
main.main()
        src/test.go:9 +0x31

goroutine 4 [chan send]:
github.com/nsf/termbox-go.input_event_producer()
        src/github.com/nsf/termbox-go/termbox_windows.go:782 +0x4f4
created by github.com/nsf/termbox-go.Init
        src/github.com/nsf/termbox-go/api_windows.go:68 +0x4ac
exit status 2
```
