### PR TITLE
Fix accidental too-relaxed build constraint

### DIFF
--- a/syscalls_darwin.go
+++ b/syscalls_darwin.go
@@ -1,6 +1,8 @@
 // Created by cgo -godefs - DO NOT EDIT
 // cgo -godefs syscalls.go
 
+// +build !amd64
+
 package termbox
 
 type syscall_Termios struct {


### PR DESCRIPTION
Sorry, my previous https://github.com/nsf/termbox-go/commit/c4d5eeeb18b378c361f9f2a731680e8b835969ed commit to fix the issue actually broke the darwin/amd64. I misinterpreted how the Go build constraint works and the one without the architecture prefix is being build even for the `amd64` architecture. This follow up PR adds a build flag to the more generic `syscalls_darwin.go` file to exclude `amd64`. Sorry for the screw up!