### PR TITLE
Prevent out-of-bounds error with 256 colours on Windows

### DIFF
--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -522,8 +522,16 @@ func prepare_diff_messages() {
 	}
 }
 
+func get_ct(table []word, idx int) word {
+	idx = idx & 0x0F
+	if idx >= len(table) {
+		idx = len(table) - 1
+	}
+	return table[idx]
+}
+
 func cell_to_char_info(c Cell) (attr word, wc [2]wchar) {
-	attr = color_table_fg[c.Fg&0x08] | color_table_bg[c.Bg&0x08]
+	attr = get_ct(color_table_fg, c.Fg) | get_ct(color_table_bg, c.Bg)
 	if c.Fg&AttrReverse|c.Bg&AttrReverse != 0 {
 		attr = (attr&0xF0)>>4 | (attr&0x0F)<<4
 	}

--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -523,7 +523,7 @@ func prepare_diff_messages() {
 }
 
 func cell_to_char_info(c Cell) (attr word, wc [2]wchar) {
-	attr = color_table_fg[c.Fg&0x0F] | color_table_bg[c.Bg&0x0F]
+	attr = color_table_fg[c.Fg&0x08] | color_table_bg[c.Bg&0x08]
 	if c.Fg&AttrReverse|c.Bg&AttrReverse != 0 {
 		attr = (attr&0xF0)>>4 | (attr&0x0F)<<4
 	}


### PR DESCRIPTION
It would appear 256 colours are not supported on Windows. This is expected, but in some cases a program written for 256 colours will crash when run on Windows. This change prevents the out-of-bounds error when looking up the colour tables.

Personally, I think displaying incorrect colours is a more desirable behaviour than just crashing. Termbox is really good at compatibility and I think this helps that out a little bit.

More details for this are available in the Termloop issue [#24](https://github.com/JoelOtter/termloop/issues/24).