### PR TITLE
Fix display when input multi-byte characters

### DIFF
--- a/_demos/editbox.go
+++ b/_demos/editbox.go
@@ -25,7 +25,7 @@ func rune_advance_len(r rune, pos int) int {
 	if r == '\t' {
 		return tabstop_length - pos%tabstop_length
 	}
-	return 1
+	return runewidth.RuneWidth(r)
 }
 
 func voffset_coffset(text []byte, boffset int) (voffset, coffset int) {

--- a/_demos/editbox.go
+++ b/_demos/editbox.go
@@ -117,7 +117,7 @@ func (eb *EditBox) Draw(x, y, w, h int) {
 			if rx >= 0 {
 				termbox.SetCell(x+rx, y, r, coldef, coldef)
 			}
-			lx += 1
+			lx += runewidth.RuneWidth(r)
 		}
 	next:
 		t = t[size:]


### PR DESCRIPTION
A demo code of editbox.go is not working when user inputs multi-byte characters(ex.Japanese) to it.

![sample1](https://cloud.githubusercontent.com/assets/1822861/12520341/50667d8c-c187-11e5-9028-8149752136f2.gif)

I fixed it.
![output1](https://cloud.githubusercontent.com/assets/1822861/12520383/8a0c0930-c187-11e5-8359-184e2c58031a.gif)

