### PR TITLE
Add detection of CTRL modifier to mouse events

### DIFF
--- a/api_common.go
+++ b/api_common.go
@@ -128,6 +128,7 @@ const (
 const (
 	ModAlt Modifier = 1 << iota
 	ModMotion
+	ModCtrl
 )
 
 // Cell colors, you can combine a color with multiple attributes using bitwise

--- a/termbox.go
+++ b/termbox.go
@@ -402,6 +402,10 @@ func parse_mouse_event(event *Event, buf string) (int, bool) {
 			event.Mod |= ModMotion
 		}
 
+		if n1&16 != 0 {
+			event.Mod |= ModCtrl
+		}
+
 		event.MouseX = int(n2) - 1
 		event.MouseY = int(n3) - 1
 		return mi + 1, true


### PR DESCRIPTION
I'm new to the codebase, so not sure if this is the correct approach. Also, could be worth adding SHIFT and META to, but they're generally already intercepted by terminals.