### PR TITLE
Add pxl to examples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ There are also some interesting projects using termbox-go:
  - [xterm-color-chart](https://github.com/kutuluk/xterm-color-chart) is a XTerm 256 color chart.
  - [gocui](https://github.com/jroimartin/gocui) is a minimalist Go library aimed at creating console user interfaces.
  - [dry](https://github.com/moncho/dry) is an interactive cli to manage Docker containers.
+ - [pxl](https://github.com/ichinaski/pxl) displays images in the terminal.
 
 ### API reference
 [godoc.org/github.com/nsf/termbox-go](http://godoc.org/github.com/nsf/termbox-go)


### PR DESCRIPTION
Hi,

I created this little hack to paint images in the terminal, which could not have happened without the awesome termbox-go. I wonder if you would like to add it to the examples list?