### PR TITLE
Add gone a cli pomodoro® timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ There are also some interesting projects using termbox-go:
  - [dry](https://github.com/moncho/dry) is an interactive cli to manage Docker containers.
  - [pxl](https://github.com/ichinaski/pxl) displays images in the terminal.
  - [snake-game](https://github.com/DyegoCosta/snake-game) is an implementation of the Snake game.
+ - [gone](https://github.com/guillaumebreton/gone) is a CLI pomodoro® timer.
 
 ### API reference
 [godoc.org/github.com/nsf/termbox-go](http://godoc.org/github.com/nsf/termbox-go)


### PR DESCRIPTION
This PR adds the gone pomodoro timer to the list of projects using termbox.