### PR TITLE
Remove panic("unreachable") which flunks `go vet`

### DIFF
--- a/api.go
+++ b/api.go
@@ -343,7 +343,6 @@ func PollEvent() Event {
 			return event
 		}
 	}
-	panic("unreachable")
 }
 
 // Returns the size of the internal back buffer (which is mostly the same as


### PR DESCRIPTION
`api.go` contained this line as a safeguard against coding mistakes. Unfortunately, because it was unreachable code, it flunked `go vet`. I think `go vet` is a better safeguard against bugs than this line, so I propose removing it. With this line removed, `termbox-go` is 100% clean in `go vet`.