### PR TITLE
Replace `if err != nil { return err } return nil' with 'return err'

### DIFF
--- a/termbox.go
+++ b/termbox.go
@@ -233,10 +233,7 @@ func send_char(x, y int, ch rune) {
 func flush() error {
 	_, err := io.Copy(out, &outbuf)
 	outbuf.Reset()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func send_clear() error {


### PR DESCRIPTION
This was caught by [`gosimple`](https://github.com/dominikh/go-simple). With this PR, `termbox-go` is 100% clean in `gosimple`.