### PR TITLE
Shift tab

### DIFF
--- a/api.go
+++ b/api.go
@@ -2,12 +2,15 @@
 
 package termbox
 
-import "github.com/mattn/go-runewidth"
-import "fmt"
-import "os"
-import "os/signal"
-import "syscall"
-import "runtime"
+import (
+	"fmt"
+	"os"
+	"os/signal"
+	"runtime"
+	"syscall"
+
+	"github.com/mattn/go-runewidth"
+)
 
 // public API
 

--- a/termbox.go
+++ b/termbox.go
@@ -2,14 +2,16 @@
 
 package termbox
 
-import "unicode/utf8"
-import "bytes"
-import "syscall"
-import "unsafe"
-import "strings"
-import "strconv"
-import "os"
-import "io"
+import (
+	"bytes"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"syscall"
+	"unicode/utf8"
+	"unsafe"
+)
 
 // private API
 

--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -1,9 +1,12 @@
 package termbox
 
-import "syscall"
-import "unsafe"
-import "unicode/utf16"
-import "github.com/mattn/go-runewidth"
+import (
+	"syscall"
+	"unicode/utf16"
+	"unsafe"
+
+	"github.com/mattn/go-runewidth"
+)
 
 type (
 	wchar     uint16

--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -616,6 +616,12 @@ func key_event_record_to_event(r *key_event_record) (Event, bool) {
 		}
 	}
 
+	// emulate xterm back-tab key
+	if r.unicode_char == 0x09 && r.control_key_state&shift_pressed != 0 {
+		e.Key = Key(r.virtual_scan_code | 0x200)
+		return e, true
+	}
+
 	ctrlpressed := r.control_key_state&(left_ctrl_pressed|right_ctrl_pressed) != 0
 
 	if r.virtual_key_code >= vk_f1 && r.virtual_key_code <= vk_f12 {


### PR DESCRIPTION
Shift-Tab on Linux return `\x1b[[Z` but termbox on windows doesn't send escape sequence to the apps. So this is workaround for handle Shift-Tab. Application can check shift-tab like below.

```go
if runtime.GOOS == "windows" && e.Key == 527 {
    // Shift-Tab on Windows
}
```
When we need to add bit mask for CTRL, it should be 0x400, Alt should be 0x800.
