### PR TITLE
Add 'jv' as an example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ There are also some interesting projects using termbox-go:
  - [tetris](https://github.com/MichaelS11/tetris) Go Tetris with AI option
  - [wot](https://github.com/kyu-suke/wot) Wait time during command is completed.
  - [2048-go](https://github.com/1984weed/2048-go) is 2048 in Go
+ - [jv](https://github.com/maxzender/jv) helps you view JSON on the command-line.
 
 ### API reference
 [godoc.org/github.com/nsf/termbox-go](http://godoc.org/github.com/nsf/termbox-go)


### PR DESCRIPTION
I've created a CLI tool for easily viewing prettified JSON, using termbox-go.
I really enjoyed working with termbox-go! Thanks for the great work :)