### PR TITLE
Add 'pinger' as an example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ There are also some interesting projects using termbox-go:
  - [wot](https://github.com/kyu-suke/wot) Wait time during command is completed.
  - [2048-go](https://github.com/1984weed/2048-go) is 2048 in Go
  - [jv](https://github.com/maxzender/jv) helps you view JSON on the command-line.
+ - [pinger](https://github.com/hirose31/pinger) helps you to monitor numerous hosts using ICMP ECHO_REQUEST.
 
 ### API reference
 [godoc.org/github.com/nsf/termbox-go](http://godoc.org/github.com/nsf/termbox-go)


### PR DESCRIPTION
I've created a CLI tool for monitoring numerous hosts easily, using termbox-go.
I am happy if you add pinger to examples!
