### PR TITLE
macOS delay on incomplete escape sequences to avoid spurious escape keypress detection #132

### DIFF
--- a/api.go
+++ b/api.go
@@ -8,6 +8,7 @@ import "os"
 import "os/signal"
 import "syscall"
 import "runtime"
+import "time"
 
 // public API
 
@@ -253,8 +254,8 @@ func CellBuffer() []Cell {
 // NOTE: This API is experimental and may change in future.
 func ParseEvent(data []byte) Event {
 	event := Event{Type: EventKey}
-	ok := extract_event(data, &event)
-	if !ok {
+	status := extract_event(data, &event, false)
+	if status != event_extracted {
 		return Event{Type: EventNone, N: event.N}
 	}
 	return event
@@ -303,34 +304,65 @@ func PollRawEvent(data []byte) Event {
 
 // Wait for an event and return it. This is a blocking function call.
 func PollEvent() Event {
+	// Constant governing macOS specific behavior. See https://github.com/nsf/termbox-go/issues/132
+	// This is an arbitrary delay which hopefully will be enough time for any lagging
+	// partial escape sequences to come through.
+	const esc_wait_delay = 50 * time.Millisecond
+
 	var event Event
+	var esc_wait_timer *time.Timer
+	var esc_timeout <-chan time.Time
 
 	// try to extract event from input buffer, return on success
 	event.Type = EventKey
-	ok := extract_event(inbuf, &event)
+	status := extract_event(inbuf, &event, true)
 	if event.N != 0 {
 		copy(inbuf, inbuf[event.N:])
 		inbuf = inbuf[:len(inbuf)-event.N]
 	}
-	if ok {
+	if status == event_extracted {
 		return event
+	} else if status == esc_wait {
+		esc_wait_timer = time.NewTimer(esc_wait_delay)
+		esc_timeout = esc_wait_timer.C
 	}
 
 	for {
 		select {
 		case ev := <-input_comm:
+			if esc_wait_timer != nil {
+				if !esc_wait_timer.Stop() {
+					<-esc_wait_timer.C
+				}
+				esc_wait_timer = nil
+			}
+
 			if ev.err != nil {
 				return Event{Type: EventError, Err: ev.err}
 			}
 
 			inbuf = append(inbuf, ev.data...)
 			input_comm <- ev
-			ok := extract_event(inbuf, &event)
+			status := extract_event(inbuf, &event, true)
 			if event.N != 0 {
 				copy(inbuf, inbuf[event.N:])
 				inbuf = inbuf[:len(inbuf)-event.N]
 			}
-			if ok {
+			if status == event_extracted {
+				return event
+			} else if status == esc_wait {
+				esc_wait_timer = time.NewTimer(esc_wait_delay)
+				esc_timeout = esc_wait_timer.C
+			}
+		case <-esc_timeout:
+			esc_wait_timer = nil
+
+			status := extract_event(inbuf, &event, false)
+			if event.N != 0 {
+				copy(inbuf, inbuf[event.N:])
+				inbuf = inbuf[:len(inbuf)-event.N]
+			}
+			if status == event_extracted {
 				return event
 			}
 		case <-interrupt_comm:

--- a/escwait.go
+++ b/escwait.go
@@ -1,0 +1,11 @@
+// +build !darwin
+
+package termbox
+
+// On all systems other than macOS, disable behavior which will wait before
+// deciding that the escape key was pressed, to account for partially send
+// escape sequences, especially with regard to lengthy mouse sequences.
+// See https://github.com/nsf/termbox-go/issues/132
+func enable_wait_for_escape_sequence() bool {
+	return false
+}

--- a/escwait_darwin.go
+++ b/escwait_darwin.go
@@ -1,0 +1,9 @@
+package termbox
+
+// On macOS, enable behavior which will wait before deciding that the escape
+// key was pressed, to account for partially send escape sequences, especially
+// with regard to lengthy mouse sequences.
+// See https://github.com/nsf/termbox-go/issues/132
+func enable_wait_for_escape_sequence() bool {
+	return true
+}

--- a/termbox.go
+++ b/termbox.go
@@ -41,6 +41,14 @@ type input_event struct {
 	err  error
 }
 
+type extract_event_res int
+
+const (
+	event_not_extracted extract_event_res = iota
+	event_extracted
+	esc_wait
+)
+
 var (
 	// term specific sequences
 	keys  []string
@@ -440,17 +448,27 @@ func extract_raw_event(data []byte, event *Event) bool {
 	return true
 }
 
-func extract_event(inbuf []byte, event *Event) bool {
+func extract_event(inbuf []byte, event *Event, allow_esc_wait bool) extract_event_res {
 	if len(inbuf) == 0 {
 		event.N = 0
-		return false
+		return event_not_extracted
 	}
 
 	if inbuf[0] == '\033' {
 		// possible escape sequence
 		if n, ok := parse_escape_sequence(event, inbuf); n != 0 {
 			event.N = n
-			return ok
+			if ok {
+				return event_extracted
+			} else {
+				return event_not_extracted
+			}
+		}
+
+		// possible partially read escape sequence; trigger a wait if appropriate
+		if enable_wait_for_escape_sequence() && allow_esc_wait {
+			event.N = 0
+			return esc_wait
 		}
 
 		// it's not escape sequence, then it's Alt or Esc, check input_mode
@@ -461,17 +479,17 @@ func extract_event(inbuf []byte, event *Event) bool {
 			event.Key = KeyEsc
 			event.Mod = 0
 			event.N = 1
-			return true
+			return event_extracted
 		case input_mode&InputAlt != 0:
 			// if we're in alt mode, set Alt modifier to event and redo parsing
 			event.Mod = ModAlt
-			ok := extract_event(inbuf[1:], event)
-			if ok {
+			status := extract_event(inbuf[1:], event, false)
+			if status == event_extracted {
 				event.N++
 			} else {
 				event.N = 0
 			}
-			return ok
+			return status
 		default:
 			panic("unreachable")
 		}
@@ -486,7 +504,7 @@ func extract_event(inbuf []byte, event *Event) bool {
 		event.Ch = 0
 		event.Key = Key(inbuf[0])
 		event.N = 1
-		return true
+		return event_extracted
 	}
 
 	// the only possible option is utf8 rune
@@ -494,10 +512,10 @@ func extract_event(inbuf []byte, event *Event) bool {
 		event.Ch = r
 		event.Key = 0
 		event.N = n
-		return true
+		return event_extracted
 	}
 
-	return false
+	return event_not_extracted
 }
 
 func fcntl(fd int, cmd int, arg int) (val int, err error) {


### PR DESCRIPTION
This proposed solution to the macOS partial escape sequence problem can be contrasted against #158 (which is similar to another proposal from the comment thread on #132). Compared with that solution, this one is more complicated but will handle the case where an escape sequence is interrupted such that ONLY the escape character comes through ahead of the rest of the sequence. It's not proven whether that's possible since AFAICT we don't understand the mechanism by which the escape sequences are being split up in macOS, but then the whole problem here is nondeterminism. 

Also this solution relies on an arbitrary delay which works according to my testing but is not verifiably "correct". This causes an short delay in processing of plain Escape keypresses. The delay is supposed to be long enough to let long escape sequences finish, but short enough not to be noticeable by the user. I have it set to 50 ms in my commit but this is obviously debatable and subject to observed behavior.

Whether this solution is better than the simpler one (if the simpler one were modified to be macOS only) I leave up to @nsf :)

### Outline of this solution:
- If an escape character is encountered but a full escape sequence cannot be parsed out, return a new flag to tell PollEvent to wait a bit for the rest of the sequence to come in. extract_event() now returns one of 3 states, not just a bool.
- In PollEvent, set a timer and keep a reference to its underlying channel.
- If we get another input event before the timer period elapses, stop and drain the timer and continue like normal.
- If the timer elapses before another input event comes in, try to extract_event again, this time with the wait logic disabled so that a partial sequence will be interpreted as keypresses.
- Other than on macOS, the escape wait case does not trigger, the timer remains uninitialized, and the esc_timeout channel remains nil and will never fire.
