### PR TITLE
Double the macOS escape sequence wait period after encounting spurious escape keypresses with rapid scroll events

### DIFF
--- a/api.go
+++ b/api.go
@@ -307,7 +307,7 @@ func PollEvent() Event {
 	// Constant governing macOS specific behavior. See https://github.com/nsf/termbox-go/issues/132
 	// This is an arbitrary delay which hopefully will be enough time for any lagging
 	// partial escape sequences to come through.
-	const esc_wait_delay = 50 * time.Millisecond
+	const esc_wait_delay = 100 * time.Millisecond
 
 	var event Event
 	var esc_wait_timer *time.Timer


### PR DESCRIPTION
Sorry to dredge this up again but I just noticed I can still reproduce the spurious escape keypress issue on macOS with rapidly repeated mouse wheel scroll events. Of course we don't understand what's driving the timing here so there is no perfect fix, but doubling the wait time seems to prevent any further problems in my use case. Hopefully this is good enough because I don't think I'd want to go too much higher than 100 ms -- at some point the user could start noticing the delay before a real escape keypress is registered.

@nsf is this change OK with you?