### PR TITLE
Add gotypist to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ There are also some interesting projects using termbox-go:
  - [pinger](https://github.com/hirose31/pinger) helps you to monitor numerous hosts using ICMP ECHO_REQUEST.
  - [vixl44](https://github.com/sebashwa/vixl44) lets you create pixel art inside your terminal using vim movements
  - [zterm](https://github.com/varunrau/zterm) is a typing game inspired by http://zty.pe/
+ - [gotypist](https://github.com/pb-/gotypist) is a fun touch-typing tutor following Steve Yegge's method.
 
 ### API reference
 [godoc.org/github.com/nsf/termbox-go](http://godoc.org/github.com/nsf/termbox-go)


### PR DESCRIPTION
I created a surprisingly fun touch-typing tutor that implements the method described in Steve Yegge's [classic post on touch typing](http://steve-yegge.blogspot.de/2008/09/programmings-dirtiest-little-secret.html). Would love to have it listed under examples!