### PR TITLE
Add /lib/terminfo to terminfo search path.

### DIFF
--- a/terminfo.go
+++ b/terminfo.go
@@ -69,6 +69,12 @@ func load_terminfo() ([]byte, error) {
 		}
 	}
 
+	// next, /lib/terminfo
+	data, err = ti_try_path("/lib/terminfo")
+	if err == nil {
+		return data, nil
+	}
+
 	// fall back to /usr/share/terminfo
 	return ti_try_path("/usr/share/terminfo")
 }


### PR DESCRIPTION
The debian package of ncurses searches `/lib/terminfo` before searching
`/usr/share/terminfo`.

See https://github.com/mirror/ncurses/blob/master/package/debian/rules#L83

This addresses issue https://github.com/nsf/termbox-go/issues/155
