### PR TITLE
Fix two bugs in Windows console handling

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -42,8 +42,13 @@ func Init() error {
 		return err
 	}
 
-	orig_size = get_term_size(out)
-	win_size := get_win_size(out)
+	orig_size, orig_window = get_term_size(out)
+	win_size, window := get_win_size(out)
+
+	err = fix_win_size(out, &window)
+	if err != nil {
+		return err
+	}
 
 	err = set_console_screen_buffer_size(out, win_size)
 	if err != nil {
@@ -56,7 +61,7 @@ func Init() error {
 	}
 
 	show_cursor(false)
-	term_size = get_term_size(out)
+	term_size, _ = get_term_size(out)
 	back_buffer.init(int(term_size.x), int(term_size.y))
 	front_buffer.init(int(term_size.x), int(term_size.y))
 	back_buffer.clear()
@@ -86,9 +91,10 @@ func Close() {
 	}
 	<-cancel_done_comm
 
+	set_console_screen_buffer_size(out, orig_size)
+	set_console_window_info(out, &orig_window)
 	set_console_cursor_info(out, &orig_cursor_info)
 	set_console_cursor_position(out, coord{})
-	set_console_screen_buffer_size(out, orig_size)
 	set_console_mode(in, orig_mode)
 	syscall.Close(in)
 	syscall.Close(out)

--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -76,6 +76,10 @@ func (this coord) uintptr() uintptr {
 	return uintptr(*(*int32)(unsafe.Pointer(&this)))
 }
 
+func (this *small_rect) uintptr() uintptr {
+	return uintptr(unsafe.Pointer(this))
+}
+
 var kernel32 = syscall.NewLazyDLL("kernel32.dll")
 var moduser32 = syscall.NewLazyDLL("user32.dll")
 var is_cjk = runewidth.IsEastAsian()
@@ -83,6 +87,7 @@ var is_cjk = runewidth.IsEastAsian()
 var (
 	proc_set_console_active_screen_buffer = kernel32.NewProc("SetConsoleActiveScreenBuffer")
 	proc_set_console_screen_buffer_size   = kernel32.NewProc("SetConsoleScreenBufferSize")
+	proc_set_console_window_info          = kernel32.NewProc("SetConsoleWindowInfo")
 	proc_create_console_screen_buffer     = kernel32.NewProc("CreateConsoleScreenBuffer")
 	proc_get_console_screen_buffer_info   = kernel32.NewProc("GetConsoleScreenBufferInfo")
 	proc_write_console_output             = kernel32.NewProc("WriteConsoleOutputW")
@@ -119,6 +124,21 @@ func set_console_active_screen_buffer(h syscall.Handle) (err error) {
 func set_console_screen_buffer_size(h syscall.Handle, size coord) (err error) {
 	r0, _, e1 := syscall.Syscall(proc_set_console_screen_buffer_size.Addr(),
 		2, uintptr(h), size.uintptr(), 0)
+	if int(r0) == 0 {
+		if e1 != 0 {
+			err = error(e1)
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+	return
+}
+
+func set_console_window_info(h syscall.Handle, window *small_rect) (err error) {
+	var absolute uint32
+	absolute = 1
+	r0, _, e1 := syscall.Syscall(proc_set_console_window_info.Addr(),
+		3, uintptr(h), uintptr(absolute), window.uintptr())
 	if int(r0) == 0 {
 		if e1 != 0 {
 			err = error(e1)
@@ -278,7 +298,7 @@ func set_console_mode(h syscall.Handle, mode dword) (err error) {
 }
 
 func fill_console_output_character(h syscall.Handle, char wchar, n int) (err error) {
-    tmp_coord  = coord{0, 0}
+	tmp_coord = coord{0, 0}
 	r0, _, e1 := syscall.Syscall6(proc_fill_console_output_character.Addr(),
 		5, uintptr(h), uintptr(char), uintptr(n), tmp_coord.uintptr(),
 		uintptr(unsafe.Pointer(&tmp_arg)), 0)
@@ -293,7 +313,7 @@ func fill_console_output_character(h syscall.Handle, char wchar, n int) (err err
 }
 
 func fill_console_output_attribute(h syscall.Handle, attr word, n int) (err error) {
-    tmp_coord  = coord{0, 0}
+	tmp_coord = coord{0, 0}
 	r0, _, e1 := syscall.Syscall6(proc_fill_console_output_attribute.Addr(),
 		5, uintptr(h), uintptr(attr), uintptr(n), tmp_coord.uintptr(),
 		uintptr(unsafe.Pointer(&tmp_arg)), 0)
@@ -374,6 +394,7 @@ type input_event struct {
 var (
 	orig_cursor_info console_cursor_info
 	orig_size        coord
+	orig_window      small_rect
 	orig_mode        dword
 	orig_screen      syscall.Handle
 	back_buffer      cellbuf
@@ -415,12 +436,12 @@ func get_cursor_position(out syscall.Handle) coord {
 	return tmp_info.cursor_position
 }
 
-func get_term_size(out syscall.Handle) coord {
+func get_term_size(out syscall.Handle) (coord, small_rect) {
 	err := get_console_screen_buffer_info(out, &tmp_info)
 	if err != nil {
 		panic(err)
 	}
-	return tmp_info.size
+	return tmp_info.size, tmp_info.window
 }
 
 func get_win_min_size(out syscall.Handle) coord {
@@ -444,7 +465,7 @@ func get_win_min_size(out syscall.Handle) coord {
 	}
 }
 
-func get_win_size(out syscall.Handle) coord {
+func get_win_size(out syscall.Handle) (coord, small_rect) {
 	err := get_console_screen_buffer_info(out, &tmp_info)
 	if err != nil {
 		panic(err)
@@ -465,13 +486,22 @@ func get_win_size(out syscall.Handle) coord {
 		size.y = min_size.y
 	}
 
-	return size
+	return size, tmp_info.window
+}
+
+func fix_win_size(out syscall.Handle, window *small_rect) (err error) {
+	window.bottom -= window.top
+	window.top = 0
+	window.right -= window.left
+	window.left = 0
+	return set_console_window_info(out, window)
 }
 
 func update_size_maybe() {
-	size := get_win_size(out)
+	size, window := get_win_size(out)
 	if size.x != term_size.x || size.y != term_size.y {
 		set_console_screen_buffer_size(out, size)
+		fix_win_size(out, &window)
 		term_size = size
 		back_buffer.resize(int(size.x), int(size.y))
 		front_buffer.resize(int(size.x), int(size.y))
@@ -492,8 +522,8 @@ var color_table_bg = []word{
 	background_green,
 	background_red | background_green, // yellow
 	background_blue,
-	background_red | background_blue,                    // magenta
-	background_green | background_blue,                  // cyan
+	background_red | background_blue,   // magenta
+	background_green | background_blue, // cyan
 	background_red | background_blue | background_green, // white
 }
 
@@ -504,8 +534,8 @@ var color_table_fg = []word{
 	foreground_green,
 	foreground_red | foreground_green, // yellow
 	foreground_blue,
-	foreground_red | foreground_blue,                    // magenta
-	foreground_green | foreground_blue,                  // cyan
+	foreground_red | foreground_blue,   // magenta
+	foreground_green | foreground_blue, // cyan
 	foreground_red | foreground_blue | foreground_green, // white
 }
 

--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -278,6 +278,7 @@ func set_console_mode(h syscall.Handle, mode dword) (err error) {
 }
 
 func fill_console_output_character(h syscall.Handle, char wchar, n int) (err error) {
+    tmp_coord  = coord{0, 0}
 	r0, _, e1 := syscall.Syscall6(proc_fill_console_output_character.Addr(),
 		5, uintptr(h), uintptr(char), uintptr(n), tmp_coord.uintptr(),
 		uintptr(unsafe.Pointer(&tmp_arg)), 0)
@@ -292,6 +293,7 @@ func fill_console_output_character(h syscall.Handle, char wchar, n int) (err err
 }
 
 func fill_console_output_attribute(h syscall.Handle, attr word, n int) (err error) {
+    tmp_coord  = coord{0, 0}
 	r0, _, e1 := syscall.Syscall6(proc_fill_console_output_attribute.Addr(),
 		5, uintptr(h), uintptr(attr), uintptr(n), tmp_coord.uintptr(),
 		uintptr(unsafe.Pointer(&tmp_arg)), 0)


### PR DESCRIPTION
This PR fixes two bugs:
1. Earlier code was not clearing the screen fully and the fix for that is in first commit.
2. The other issue is more intricate, it was causing termbox to paint content in invisible portion of console.
This issue only happens when you launch termbox application when existing console buffer is scrolled down. See attached screenshot (#1) and (#2). With the fix, the problem goes away and console is painted correctly as we fix the window position by calling SetConsoleWindowInfo.

![image](https://user-images.githubusercontent.com/590987/47607548-52ca0480-d9d6-11e8-929f-d361ab4ea446.png)

![image](https://user-images.githubusercontent.com/590987/47607552-62e1e400-d9d6-11e8-8f21-22d06f1297cf.png)

