### PR TITLE
Reorder SetConsoleScreenBufferSize and SetConsoleWindowInfo.

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -43,14 +43,14 @@ func Init() error {
 	}
 
 	orig_size, orig_window = get_term_size(out)
-	win_size, window := get_win_size(out)
+	win_size := get_win_size(out)
 
 	err = set_console_screen_buffer_size(out, win_size)
 	if err != nil {
 		return err
 	}
 
-	err = fix_win_size(out, &window)
+	err = fix_win_size(out, win_size)
 	if err != nil {
 		return err
 	}

--- a/api_windows.go
+++ b/api_windows.go
@@ -45,12 +45,12 @@ func Init() error {
 	orig_size, orig_window = get_term_size(out)
 	win_size, window := get_win_size(out)
 
-	err = fix_win_size(out, &window)
+	err = set_console_screen_buffer_size(out, win_size)
 	if err != nil {
 		return err
 	}
 
-	err = set_console_screen_buffer_size(out, win_size)
+	err = fix_win_size(out, &window)
 	if err != nil {
 		return err
 	}

--- a/termbox_windows.go
+++ b/termbox_windows.go
@@ -465,7 +465,7 @@ func get_win_min_size(out syscall.Handle) coord {
 	}
 }
 
-func get_win_size(out syscall.Handle) (coord, small_rect) {
+func get_win_size(out syscall.Handle) coord {
 	err := get_console_screen_buffer_info(out, &tmp_info)
 	if err != nil {
 		panic(err)
@@ -486,22 +486,23 @@ func get_win_size(out syscall.Handle) (coord, small_rect) {
 		size.y = min_size.y
 	}
 
-	return size, tmp_info.window
+	return size
 }
 
-func fix_win_size(out syscall.Handle, window *small_rect) (err error) {
-	window.bottom -= window.top
+func fix_win_size(out syscall.Handle, size coord) (err error) {
+	window := small_rect{}
 	window.top = 0
-	window.right -= window.left
+	window.bottom = size.y - 1
 	window.left = 0
-	return set_console_window_info(out, window)
+	window.right = size.x - 1
+	return set_console_window_info(out, &window)
 }
 
 func update_size_maybe() {
-	size, window := get_win_size(out)
+	size := get_win_size(out)
 	if size.x != term_size.x || size.y != term_size.y {
 		set_console_screen_buffer_size(out, size)
-		fix_win_size(out, &window)
+		fix_win_size(out, size)
 		term_size = size
 		back_buffer.resize(int(size.x), int(size.y))
 		front_buffer.resize(int(size.x), int(size.y))


### PR DESCRIPTION
This ensures that outer console window is correctly resized.

The issue is shown below and described below the picture.
![image](https://user-images.githubusercontent.com/590987/47610081-70609380-da01-11e8-8e39-15e4d5edf2e7.png)
If you have a console window (on windows 10) with vertical scroll bar (Picture#1 from left), then first calling SetConsoleWindowInfo and then calling SetConsoleScreenBufferSize results in empty space (shown in picture #2 with red rectangle).

The correct way is to reverse these i.e. first change ScreenBufferSize and then the window size. The update_size_maybe() function had the right change, but I missed this in Init() in my previous commit. The picture #3 shows that with this PR, we get the console window size change correctly.