### PR TITLE
FireEvent method in API

### DIFF
--- a/api.go
+++ b/api.go
@@ -487,3 +487,8 @@ func Sync() error {
 
 	return Flush()
 }
+
+//FireEvent is used to fire event when needed. Mostly for testing purpose
+func FireEvent(data []byte) {
+	input_comm <- input_event{data, nil}
+}


### PR DESCRIPTION
I have some experience using this library.
Sometimes it would be nice to have an ability to fire keyboard event in tests.
For example in such case:

```
func Listen() {
  for {
    e := termbox.PollEvent()

    switch e.Type {
    case termbox.EventKey:
      //do smth
    case termbox.EventInterrupt:
      //do smth
    case termbox.EventError:
      //do smth
    }
  }
}
```