### PR TITLE
Fix multibyte-strings

### DIFF
--- a/api_windows.go
+++ b/api_windows.go
@@ -2,6 +2,8 @@ package termbox
 
 import (
 	"syscall"
+
+	"github.com/mattn/go-runewidth"
 )
 
 // public API
@@ -114,13 +116,23 @@ func Flush() error {
 	update_size_maybe()
 	prepare_diff_messages()
 	for _, diff := range diffbuf {
+		chars := []char_info{}
+		for _, char := range diff.chars {
+			chars = append(chars, char)
+			if runewidth.RuneWidth(rune(char.char)) > 1 {
+				chars = append(chars, char_info{
+					char: ' ',
+					attr: char.attr,
+				})
+			}
+		}
 		r := small_rect{
 			left:   0,
 			top:    diff.pos,
 			right:  term_size.x - 1,
 			bottom: diff.pos + diff.lines - 1,
 		}
-		write_console_output(out, diff.chars, r)
+		write_console_output(out, chars, r)
 	}
 	if !is_cursor_hidden(cursor_x, cursor_y) {
 		move_cursor(cursor_x, cursor_y)


### PR DESCRIPTION
On Windows 10, WriteConsoleOutputW break compatibility. When writing three unicode characters, the character is displayed overlayed with 3 cells.

```c
#include <windows.h>
#include <stdio.h>

int
main(int argc, char* argv[]) {
	HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
	CHAR_INFO ci[3] = {};
	COORD buffer_size = { 3, 1 };
	COORD start_coord = { 0, 0 };
	SMALL_RECT sr = { 0, 0, 80, 25 };
	SHORT white = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED;

	ci[0].Char.UnicodeChar = L'あ';
	ci[0].Attributes = white;
	ci[1].Char.UnicodeChar = L'い';
	ci[1].Attributes = white;
	ci[2].Char.UnicodeChar = L'う';
	ci[2].Attributes = white;
	WriteConsoleOutputW(h, (CHAR_INFO*)ci, buffer_size, start_coord, &sr);	
	return 0;
}
```

![image](https://user-images.githubusercontent.com/10111/63212262-b0356a80-c13c-11e9-89eb-681a492086cd.png)

Currently, all of products using termbox-go does not work correctly with wide characters on Windows 10.

This is a problem. However, I thought that WriteConsoleOutputW have design problem for a long time. WriteConsoleOutputW can be specified buffer size and rectangle size. The buffer size is a length of char_info array. But the character might be 2 cells. So this mean that this API can be specified sizes over expected width. For example, display 80 characters with the buffer size 80, it possibly require 160 cells.

To fix this problem, we must add spaces after the each 2 cells characters.

```c
#include <windows.h>
#include <stdio.h>

int
main(int argc, char* argv[]) {
	HANDLE h = GetStdHandle(STD_OUTPUT_HANDLE);
	CHAR_INFO ci[6] = {};
	COORD buffer_size = { 6, 1 };
	COORD start_coord = { 0, 0 };
	SMALL_RECT sr = { 0, 0, 80, 25 };
	SHORT white = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED;

	ci[0].Char.UnicodeChar = L'あ';
	ci[0].Attributes = white;
	ci[1].Char.UnicodeChar = L' ';
	ci[1].Attributes = white;
	ci[2].Char.UnicodeChar = L'い';
	ci[2].Attributes = white;
	ci[3].Char.UnicodeChar = L' ';
	ci[3].Attributes = white;
	ci[4].Char.UnicodeChar = L'う';
	ci[4].Attributes = white;
	ci[5].Char.UnicodeChar = L' ';
	ci[5].Attributes = white;
	WriteConsoleOutputW(h, (CHAR_INFO*)ci, buffer_size, start_coord, &sr);	
	return 0;
}
```

![image](https://user-images.githubusercontent.com/10111/63212346-0525b080-c13e-11e9-802a-eafdd97141cb.png)

