### PR TITLE
Fix demos

### DIFF
--- a/_demos/editbox.go
+++ b/_demos/editbox.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"unicode/utf8"
+
 	"github.com/mattn/go-runewidth"
 	"github.com/nsf/termbox-go"
-	"unicode/utf8"
 )
 
 func tbprint(x, y int, fg, bg termbox.Attribute, msg string) {
@@ -80,6 +81,8 @@ func (eb *EditBox) Draw(x, y, w, h int) {
 	eb.AdjustVOffset(w)
 
 	const coldef = termbox.ColorDefault
+	const colred = termbox.ColorRed
+
 	fill(x, y, w, h, termbox.Cell{Ch: ' '})
 
 	t := eb.text
@@ -96,8 +99,8 @@ func (eb *EditBox) Draw(x, y, w, h int) {
 		}
 
 		if rx >= w {
-			termbox.SetCell(x+w-1, y, '→',
-				coldef, coldef)
+			termbox.SetCell(x+w-1, y, arrowRight,
+				colred, coldef)
 			break
 		}
 
@@ -124,7 +127,7 @@ func (eb *EditBox) Draw(x, y, w, h int) {
 	}
 
 	if eb.line_voffset != 0 {
-		termbox.SetCell(x, y, '←', coldef, coldef)
+		termbox.SetCell(x, y, arrowLeft, colred, coldef)
 	}
 }
 
@@ -237,20 +240,41 @@ func redraw_all() {
 	midx := (w - edit_box_width) / 2
 
 	// unicode box drawing chars around the edit box
-	termbox.SetCell(midx-1, midy, '│', coldef, coldef)
-	termbox.SetCell(midx+edit_box_width, midy, '│', coldef, coldef)
-	termbox.SetCell(midx-1, midy-1, '┌', coldef, coldef)
-	termbox.SetCell(midx-1, midy+1, '└', coldef, coldef)
-	termbox.SetCell(midx+edit_box_width, midy-1, '┐', coldef, coldef)
-	termbox.SetCell(midx+edit_box_width, midy+1, '┘', coldef, coldef)
-	fill(midx, midy-1, edit_box_width, 1, termbox.Cell{Ch: '─'})
-	fill(midx, midy+1, edit_box_width, 1, termbox.Cell{Ch: '─'})
+	if runewidth.EastAsianWidth {
+		termbox.SetCell(midx-1, midy, '|', coldef, coldef)
+		termbox.SetCell(midx+edit_box_width, midy, '|', coldef, coldef)
+		termbox.SetCell(midx-1, midy-1, '+', coldef, coldef)
+		termbox.SetCell(midx-1, midy+1, '+', coldef, coldef)
+		termbox.SetCell(midx+edit_box_width, midy-1, '+', coldef, coldef)
+		termbox.SetCell(midx+edit_box_width, midy+1, '+', coldef, coldef)
+		fill(midx, midy-1, edit_box_width, 1, termbox.Cell{Ch: '-'})
+		fill(midx, midy+1, edit_box_width, 1, termbox.Cell{Ch: '-'})
+	} else {
+		termbox.SetCell(midx-1, midy, '│', coldef, coldef)
+		termbox.SetCell(midx+edit_box_width, midy, '│', coldef, coldef)
+		termbox.SetCell(midx-1, midy-1, '┌', coldef, coldef)
+		termbox.SetCell(midx-1, midy+1, '└', coldef, coldef)
+		termbox.SetCell(midx+edit_box_width, midy-1, '┐', coldef, coldef)
+		termbox.SetCell(midx+edit_box_width, midy+1, '┘', coldef, coldef)
+		fill(midx, midy-1, edit_box_width, 1, termbox.Cell{Ch: '─'})
+		fill(midx, midy+1, edit_box_width, 1, termbox.Cell{Ch: '─'})
+	}
 
 	edit_box.Draw(midx, midy, edit_box_width, 1)
 	termbox.SetCursor(midx+edit_box.CursorX(), midy)
 
 	tbprint(midx+6, midy+3, coldef, coldef, "Press ESC to quit")
 	termbox.Flush()
+}
+
+var arrowLeft = '←'
+var arrowRight = '→'
+
+func init() {
+	if runewidth.EastAsianWidth {
+		arrowLeft = '<'
+		arrowRight = '>'
+	}
 }
 
 func main() {

--- a/_demos/keyboard.go
+++ b/_demos/keyboard.go
@@ -1,7 +1,11 @@
 package main
 
-import "github.com/nsf/termbox-go"
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/nsf/termbox-go"
+)
 
 type key struct {
 	x  int
@@ -172,6 +176,37 @@ var K_ARROW_DOWN = []key{{54, 12, '('}, {55, 12, 0x2193}, {56, 12, ')'}}
 var K_ARROW_RIGHT = []key{{58, 12, '('}, {59, 12, 0x2192}, {60, 12, ')'}}
 var K_K_0 = []key{{65, 12, ' '}, {66, 12, '0'}, {67, 12, ' '}, {68, 12, ' '}}
 var K_K_PERIOD = []key{{71, 12, '.'}}
+
+var borderTopLeft rune = 0x250C
+var borderTopRight rune = 0x2510
+var borderBotomLeft rune = 0x2514
+var borderBottomRight rune = 0x2518
+var borderVertical rune = 0x2500
+var borderHorizontal rune = 0x2502
+var borderHorizontalLeftBar rune = 0x251C
+var borderHorizontalRight rune = 0x2524
+var boxShadow rune = 0x2588
+
+func init() {
+	if runewidth.EastAsianWidth {
+		K_BACKSPACE[0].ch = '<'
+		K_BACKSPACE[1].ch = '-'
+		K_BACKSPACE[2].ch = '-'
+		K_ARROW_UP[1].ch = '^'
+		K_ARROW_DOWN[1].ch = 'v'
+		K_ARROW_LEFT[1].ch = '<'
+		K_ARROW_RIGHT[1].ch = '>'
+		borderTopLeft = '+'
+		borderTopRight = '+'
+		borderBotomLeft = '+'
+		borderBottomRight = '+'
+		borderVertical = '-'
+		borderHorizontal = '|'
+		borderHorizontalLeftBar = '+'
+		borderHorizontalRight = '+'
+		boxShadow = ' '
+	}
+}
 
 type combo struct {
 	keys [][]key
@@ -352,28 +387,28 @@ func draw_key(k []key, fg, bg termbox.Attribute) {
 }
 
 func draw_keyboard() {
-	termbox.SetCell(0, 0, 0x250C, termbox.ColorWhite, termbox.ColorBlack)
-	termbox.SetCell(79, 0, 0x2510, termbox.ColorWhite, termbox.ColorBlack)
-	termbox.SetCell(0, 23, 0x2514, termbox.ColorWhite, termbox.ColorBlack)
-	termbox.SetCell(79, 23, 0x2518, termbox.ColorWhite, termbox.ColorBlack)
+	termbox.SetCell(0, 0, borderTopLeft, termbox.ColorWhite, termbox.ColorBlack)
+	termbox.SetCell(79, 0, borderTopRight, termbox.ColorWhite, termbox.ColorBlack)
+	termbox.SetCell(0, 23, borderBotomLeft, termbox.ColorWhite, termbox.ColorBlack)
+	termbox.SetCell(79, 23, borderBottomRight, termbox.ColorWhite, termbox.ColorBlack)
 
 	for i := 1; i < 79; i++ {
-		termbox.SetCell(i, 0, 0x2500, termbox.ColorWhite, termbox.ColorBlack)
-		termbox.SetCell(i, 23, 0x2500, termbox.ColorWhite, termbox.ColorBlack)
-		termbox.SetCell(i, 17, 0x2500, termbox.ColorWhite, termbox.ColorBlack)
-		termbox.SetCell(i, 4, 0x2500, termbox.ColorWhite, termbox.ColorBlack)
+		termbox.SetCell(i, 0, borderVertical, termbox.ColorWhite, termbox.ColorBlack)
+		termbox.SetCell(i, 23, borderVertical, termbox.ColorWhite, termbox.ColorBlack)
+		termbox.SetCell(i, 17, borderVertical, termbox.ColorWhite, termbox.ColorBlack)
+		termbox.SetCell(i, 4, borderVertical, termbox.ColorWhite, termbox.ColorBlack)
 	}
 	for i := 1; i < 23; i++ {
-		termbox.SetCell(0, i, 0x2502, termbox.ColorWhite, termbox.ColorBlack)
-		termbox.SetCell(79, i, 0x2502, termbox.ColorWhite, termbox.ColorBlack)
+		termbox.SetCell(0, i, borderHorizontal, termbox.ColorWhite, termbox.ColorBlack)
+		termbox.SetCell(79, i, borderHorizontal, termbox.ColorWhite, termbox.ColorBlack)
 	}
-	termbox.SetCell(0, 17, 0x251C, termbox.ColorWhite, termbox.ColorBlack)
-	termbox.SetCell(79, 17, 0x2524, termbox.ColorWhite, termbox.ColorBlack)
-	termbox.SetCell(0, 4, 0x251C, termbox.ColorWhite, termbox.ColorBlack)
-	termbox.SetCell(79, 4, 0x2524, termbox.ColorWhite, termbox.ColorBlack)
+	termbox.SetCell(0, 17, borderHorizontalLeftBar, termbox.ColorWhite, termbox.ColorBlack)
+	termbox.SetCell(79, 17, borderHorizontalRight, termbox.ColorWhite, termbox.ColorBlack)
+	termbox.SetCell(0, 4, borderHorizontalLeftBar, termbox.ColorWhite, termbox.ColorBlack)
+	termbox.SetCell(79, 4, borderHorizontalRight, termbox.ColorWhite, termbox.ColorBlack)
 	for i := 5; i < 17; i++ {
-		termbox.SetCell(1, i, 0x2588, termbox.ColorYellow, termbox.ColorYellow)
-		termbox.SetCell(78, i, 0x2588, termbox.ColorYellow, termbox.ColorYellow)
+		termbox.SetCell(1, i, boxShadow, termbox.ColorYellow, termbox.ColorYellow)
+		termbox.SetCell(78, i, boxShadow, termbox.ColorYellow, termbox.ColorYellow)
 	}
 
 	draw_key(K_ESC, termbox.ColorWhite, termbox.ColorBlue)


### PR DESCRIPTION
Border characters take 2 cells in east asian aibiguous width. So use ASCII characters instead for them.

![image](https://user-images.githubusercontent.com/10111/63212601-0a84fa00-c142-11e9-810b-e5a0ba23418e.png)

![image](https://user-images.githubusercontent.com/10111/63212610-28eaf580-c142-11e9-9e07-e39df76bc028.png)
