### PR TITLE
Fix crashes and odd behaviour due to builtin terminfo inconsistencies

### DIFF
--- a/termbox.go
+++ b/termbox.go
@@ -17,7 +17,8 @@ const (
 	// for future contributors: after adding something here,
 	// you have to add the corresponding index in a terminfo
 	// file to `terminfo.go#ti_funcs`. The values can be taken
-	// from (ncurses) `term.h`.
+	// from (ncurses) `term.h`. The builtin terminfo at terminfo_builtin.go
+	// also needs adjusting with the new values.
 	t_enter_ca = iota
 	t_exit_ca
 	t_show_cursor

--- a/terminfo_builtin.go
+++ b/terminfo_builtin.go
@@ -7,7 +7,23 @@ var eterm_keys = []string{
 	"\x1b[11~", "\x1b[12~", "\x1b[13~", "\x1b[14~", "\x1b[15~", "\x1b[17~", "\x1b[18~", "\x1b[19~", "\x1b[20~", "\x1b[21~", "\x1b[23~", "\x1b[24~", "\x1b[2~", "\x1b[3~", "\x1b[7~", "\x1b[8~", "\x1b[5~", "\x1b[6~", "\x1b[A", "\x1b[B", "\x1b[D", "\x1b[C",
 }
 var eterm_funcs = []string{
-	"\x1b7\x1b[?47h", "\x1b[2J\x1b[?47l\x1b8", "\x1b[?25h", "\x1b[?25l", "\x1b[H\x1b[2J", "\x1b[m\x0f", "\x1b[4m", "\x1b[1m", "\x1b[5m", "\x1b[7m", "", "", "", "",
+	t_enter_ca:     "\x1b7\x1b[?47h",
+	t_exit_ca:      "\x1b[2J\x1b[?47l\x1b8",
+	t_show_cursor:  "\x1b[?25h",
+	t_hide_cursor:  "\x1b[?25l",
+	t_clear_screen: "\x1b[H\x1b[2J",
+	t_sgr0:         "\x1b[m\x0f",
+	t_underline:    "\x1b[4m",
+	t_bold:         "\x1b[1m",
+	t_hidden:       "",
+	t_blink:        "\x1b[5m",
+	t_dim:          "",
+	t_cursive:      "",
+	t_reverse:      "\x1b[7m",
+	t_enter_keypad: "",
+	t_exit_keypad:  "",
+	t_enter_mouse:  "",
+	t_exit_mouse:   "",
 }
 
 // screen
@@ -15,7 +31,23 @@ var screen_keys = []string{
 	"\x1bOP", "\x1bOQ", "\x1bOR", "\x1bOS", "\x1b[15~", "\x1b[17~", "\x1b[18~", "\x1b[19~", "\x1b[20~", "\x1b[21~", "\x1b[23~", "\x1b[24~", "\x1b[2~", "\x1b[3~", "\x1b[1~", "\x1b[4~", "\x1b[5~", "\x1b[6~", "\x1bOA", "\x1bOB", "\x1bOD", "\x1bOC",
 }
 var screen_funcs = []string{
-	"\x1b[?1049h", "\x1b[?1049l", "\x1b[34h\x1b[?25h", "\x1b[?25l", "\x1b[H\x1b[J", "\x1b[m\x0f", "\x1b[4m", "\x1b[1m", "\x1b[5m", "\x1b[7m", "\x1b[?1h\x1b=", "\x1b[?1l\x1b>", ti_mouse_enter, ti_mouse_leave,
+	t_enter_ca:     "\x1b[?1049h",
+	t_exit_ca:      "\x1b[?1049l",
+	t_show_cursor:  "\x1b[34h\x1b[?25h",
+	t_hide_cursor:  "\x1b[?25l",
+	t_clear_screen: "\x1b[H\x1b[J",
+	t_sgr0:         "\x1b[m\x0f",
+	t_underline:    "\x1b[4m",
+	t_bold:         "\x1b[1m",
+	t_hidden:       "",
+	t_blink:        "\x1b[5m",
+	t_dim:          "",
+	t_cursive:      "",
+	t_reverse:      "\x1b[7m",
+	t_enter_keypad: "\x1b[?1h\x1b=",
+	t_exit_keypad:  "\x1b[?1l\x1b>",
+	t_enter_mouse:  ti_mouse_enter,
+	t_exit_mouse:   ti_mouse_leave,
 }
 
 // xterm
@@ -23,7 +55,23 @@ var xterm_keys = []string{
 	"\x1bOP", "\x1bOQ", "\x1bOR", "\x1bOS", "\x1b[15~", "\x1b[17~", "\x1b[18~", "\x1b[19~", "\x1b[20~", "\x1b[21~", "\x1b[23~", "\x1b[24~", "\x1b[2~", "\x1b[3~", "\x1bOH", "\x1bOF", "\x1b[5~", "\x1b[6~", "\x1bOA", "\x1bOB", "\x1bOD", "\x1bOC",
 }
 var xterm_funcs = []string{
-	"\x1b[?1049h", "\x1b[?1049l", "\x1b[?12l\x1b[?25h", "\x1b[?25l", "\x1b[H\x1b[2J", "\x1b(B\x1b[m", "\x1b[4m", "\x1b[1m", "\x1b[5m", "\x1b[7m", "\x1b[?1h\x1b=", "\x1b[?1l\x1b>", ti_mouse_enter, ti_mouse_leave,
+	t_enter_ca:     "\x1b[?1049h",
+	t_exit_ca:      "\x1b[?1049l",
+	t_show_cursor:  "\x1b[?12l\x1b[?25h",
+	t_hide_cursor:  "\x1b[?25l",
+	t_clear_screen: "\x1b[H\x1b[2J",
+	t_sgr0:         "\x1b(B\x1b[m",
+	t_underline:    "\x1b[4m",
+	t_bold:         "\x1b[1m",
+	t_hidden:       "",
+	t_blink:        "\x1b[5m",
+	t_dim:          "",
+	t_cursive:      "",
+	t_reverse:      "\x1b[7m",
+	t_enter_keypad: "\x1b[?1h\x1b=",
+	t_exit_keypad:  "\x1b[?1l\x1b>",
+	t_enter_mouse:  ti_mouse_enter,
+	t_exit_mouse:   ti_mouse_leave,
 }
 
 // rxvt-unicode
@@ -31,7 +79,23 @@ var rxvt_unicode_keys = []string{
 	"\x1b[11~", "\x1b[12~", "\x1b[13~", "\x1b[14~", "\x1b[15~", "\x1b[17~", "\x1b[18~", "\x1b[19~", "\x1b[20~", "\x1b[21~", "\x1b[23~", "\x1b[24~", "\x1b[2~", "\x1b[3~", "\x1b[7~", "\x1b[8~", "\x1b[5~", "\x1b[6~", "\x1b[A", "\x1b[B", "\x1b[D", "\x1b[C",
 }
 var rxvt_unicode_funcs = []string{
-	"\x1b[?1049h", "\x1b[r\x1b[?1049l", "\x1b[?25h", "\x1b[?25l", "\x1b[H\x1b[2J", "\x1b[m\x1b(B", "\x1b[4m", "\x1b[1m", "\x1b[5m", "\x1b[7m", "\x1b=", "\x1b>", ti_mouse_enter, ti_mouse_leave,
+	t_enter_ca:     "\x1b[?1049h",
+	t_exit_ca:      "\x1b[r\x1b[?1049l",
+	t_show_cursor:  "\x1b[?25h",
+	t_hide_cursor:  "\x1b[?25l",
+	t_clear_screen: "\x1b[H\x1b[2J",
+	t_sgr0:         "\x1b[m\x1b(B",
+	t_underline:    "\x1b[4m",
+	t_bold:         "\x1b[1m",
+	t_hidden:       "",
+	t_blink:        "\x1b[5m",
+	t_dim:          "",
+	t_cursive:      "",
+	t_reverse:      "\x1b[7m",
+	t_enter_keypad: "\x1b=",
+	t_exit_keypad:  "\x1b>",
+	t_enter_mouse:  ti_mouse_enter,
+	t_exit_mouse:   ti_mouse_leave,
 }
 
 // linux
@@ -39,7 +103,23 @@ var linux_keys = []string{
 	"\x1b[[A", "\x1b[[B", "\x1b[[C", "\x1b[[D", "\x1b[[E", "\x1b[17~", "\x1b[18~", "\x1b[19~", "\x1b[20~", "\x1b[21~", "\x1b[23~", "\x1b[24~", "\x1b[2~", "\x1b[3~", "\x1b[1~", "\x1b[4~", "\x1b[5~", "\x1b[6~", "\x1b[A", "\x1b[B", "\x1b[D", "\x1b[C",
 }
 var linux_funcs = []string{
-	"", "", "\x1b[?25h\x1b[?0c", "\x1b[?25l\x1b[?1c", "\x1b[H\x1b[J", "\x1b[0;10m", "\x1b[4m", "\x1b[1m", "\x1b[5m", "\x1b[7m", "", "", "", "",
+	t_enter_ca:     "",
+	t_exit_ca:      "",
+	t_show_cursor:  "\x1b[?25h\x1b[?0c",
+	t_hide_cursor:  "\x1b[?25l\x1b[?1c",
+	t_clear_screen: "\x1b[H\x1b[J",
+	t_sgr0:         "\x1b[0;10m",
+	t_underline:    "\x1b[4m",
+	t_bold:         "\x1b[1m",
+	t_hidden:       "",
+	t_blink:        "\x1b[5m",
+	t_dim:          "",
+	t_cursive:      "",
+	t_reverse:      "\x1b[7m",
+	t_enter_keypad: "",
+	t_exit_keypad:  "",
+	t_enter_mouse:  "",
+	t_exit_mouse:   "",
 }
 
 // rxvt-256color
@@ -47,7 +127,23 @@ var rxvt_256color_keys = []string{
 	"\x1b[11~", "\x1b[12~", "\x1b[13~", "\x1b[14~", "\x1b[15~", "\x1b[17~", "\x1b[18~", "\x1b[19~", "\x1b[20~", "\x1b[21~", "\x1b[23~", "\x1b[24~", "\x1b[2~", "\x1b[3~", "\x1b[7~", "\x1b[8~", "\x1b[5~", "\x1b[6~", "\x1b[A", "\x1b[B", "\x1b[D", "\x1b[C",
 }
 var rxvt_256color_funcs = []string{
-	"\x1b7\x1b[?47h", "\x1b[2J\x1b[?47l\x1b8", "\x1b[?25h", "\x1b[?25l", "\x1b[H\x1b[2J", "\x1b[m\x0f", "\x1b[4m", "\x1b[1m", "\x1b[5m", "\x1b[7m", "\x1b=", "\x1b>", ti_mouse_enter, ti_mouse_leave,
+	t_enter_ca:     "\x1b7\x1b[?47h",
+	t_exit_ca:      "\x1b[2J\x1b[?47l\x1b8",
+	t_show_cursor:  "\x1b[?25h",
+	t_hide_cursor:  "\x1b[?25l",
+	t_clear_screen: "\x1b[H\x1b[2J",
+	t_sgr0:         "\x1b[m\x0f",
+	t_underline:    "\x1b[4m",
+	t_bold:         "\x1b[1m",
+	t_hidden:       "",
+	t_blink:        "\x1b[5m",
+	t_dim:          "",
+	t_cursive:      "",
+	t_reverse:      "\x1b[7m",
+	t_enter_keypad: "\x1b=",
+	t_exit_keypad:  "\x1b>",
+	t_enter_mouse:  ti_mouse_enter,
+	t_exit_mouse:   ti_mouse_leave,
 }
 
 var terms = []struct {

--- a/terminfo_builtin_test.go
+++ b/terminfo_builtin_test.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package termbox
+
+import "testing"
+
+func TestTerminfoTerms(t *testing.T) {
+	for _, term := range terms {
+		t.Run(term.name, func(t *testing.T) {
+			if len(term.funcs) != t_max_funcs {
+				t.Errorf("want %d got %d terminfo entries", t_max_funcs, len(term.funcs))
+			}
+		})
+	}
+}


### PR DESCRIPTION
In recent commits

- a08d44e997 implemented dim, blink hidden
- b53f34a171 extra attributes wip

3 more attributes were added - hidden, dim and cursive.

Unfortunately these commits didn't adjust the builtin terminfo.

This leads to crashes which look like this on quit

    panic: runtime error: index out of range [14] with length 14
    goroutine 1 [running]:
    github.com/nsf/termbox-go.Close()
        github.com/nsf/termbox-go@v1.1.0/api.go:146 +0x458

And other odd behaviour like arrow keys not being recognised.

This patch fixes the terminfo, and names all the entries to make it
easier to update. It also adds a test to make sure the terminfo
doesn't get out of sync again.

See: https://github.com/rclone/rclone/issues/5259
