### PR TITLE
Fix nonblocking read on BSD systems

### DIFF
--- a/termbox.go
+++ b/termbox.go
@@ -71,6 +71,7 @@ var (
 	input_mode     = InputEsc
 	output_mode    = OutputNormal
 	out            *os.File
+	outfd          uintptr
 	in             int
 	lastfg         = attr_invalid
 	lastbg         = attr_invalid
@@ -336,7 +337,7 @@ func send_clear() error {
 }
 
 func update_size_maybe() error {
-	w, h := get_term_size(out.Fd())
+	w, h := get_term_size(outfd)
 	if w != termw || h != termh {
 		termw, termh = w, h
 		back_buffer.resize(termw, termh)


### PR DESCRIPTION
On FreeBSD and OpenBSD, the `syscall.Read` call in the anonymous goroutine in `Init` blocks.  This causes problems during `Close`: the send to the `quit` channel blocks, because the anonymous goroutine is blocked on `syscall.Read`, and things remain blocked until `syscall.Read` returns.

`Init` sets the `in` file descriptor to nonblocking with `fcntl`, but—on FreeBSD and OpenBSD—the `in` fd and the `out` fd are the same, and every `out.Fd` call [clears nonblocking flag](https://github.com/golang/go/blob/f229e7031a6efb2f23241b5da000c3b3203081d6/src/os/file_unix.go#L85).  This problem can be fixed by saving the `out.Fd` in a variable prior to setting the `in` fd to nonblocking, and using that variable afterward instead of `out.Fd`.

https://github.com/nsf/termbox-go/issues/167 is related.

This fixes a bug in [godit](https://github.com/nsf/godit) on FreeBSD.  Without this change, `C-x C-c` hangs, leaving the editor on the screen: to clear the hang, you have to type arbitrary characters so that the `syscall.Read` returns and then the anonymous goroutine picks up on the quit signal.  With this change, `C-x C-c` works correctly on FreeBSD.