### PR TITLE
Wait for key event rather than all events on 16colortest

### DIFF
--- a/_demos/16colortest.go
+++ b/_demos/16colortest.go
@@ -61,6 +61,9 @@ func main() {
 	tbprint(15, i+4, termbox.ColorDefault, termbox.ColorDefault,
 		"Press any key to close...")
 	termbox.Flush()
-	termbox.PollEvent()
+
+	for termbox.PollEvent().Type != termbox.EventKey {
+	}
+
 	termbox.Close()
 }


### PR DESCRIPTION
At least on my machine, the `16colortest.go` demo would instantly return, without letting me see its output. Before when the user was prompted "Press any key to close", the program waited for any event. Now it will only terminate when it receives an event from a key press